### PR TITLE
 添加译注区分attribute与property二词

### DIFF
--- a/2-ui/1-document/11-coordinates/article.md
+++ b/2-ui/1-document/11-coordinates/article.md
@@ -205,7 +205,7 @@ function getCoords(elem) {
 页面上的任何点都有坐标：
 
 3. 相对于窗口的坐标 — `elem.getBoundingClientRect()`。
-4. 相对于文档的坐标 — elem.getBoundingClientRect()` 加上当前页面滚动的长度。
+4. 相对于文档的坐标 — `elem.getBoundingClientRect()` 加上当前页面滚动的长度。
 
 窗口坐标非常适合和 `position:fixed` 一起使用，文档坐标非常适合和 `position:absolute` 一起使用。
 


### PR DESCRIPTION
From [#321](https://github.com/xitu/javascript-tutorial-zh/issues/321)

经查找资料发现：

- 《JavaScript高级程序设计（第3版）》中 Attributes 译为“特性”
- 《JavaScript权威指南》中对 Attributes 有“特定的属性”的说法

做出以下小小的修改以提高阅读体验：

1. 添加译注
2. 把一些“Attributes”改为“特性”