### PR TITLE
Update translation of 1-js/05-data-types/03-string

### DIFF
--- a/1-js/05-data-types/03-string/1-ucfirst/solution.md
+++ b/1-js/05-data-types/03-string/1-ucfirst/solution.md
@@ -15,7 +15,7 @@ let newStr = str[0].toUpperCase() + str.slice(1);
 
 这是第二种变体：
 
-```js run
+```js run demo
 function ucFirst(str) {
   if (!str) return str;
 

--- a/1-js/05-data-types/03-string/1-ucfirst/task.md
+++ b/1-js/05-data-types/03-string/1-ucfirst/task.md
@@ -4,7 +4,7 @@ importance: 5
 
 # 首字母大写
 
-写一个函数 `ucFirst(str)`，并返回首字母大写的字符串` str`，例如：
+写一个函数 `ucFirst(str)`，并返回首字母大写的字符串 `str`，例如：
 
 ```js
 ucFirst("john") == "John";

--- a/1-js/05-data-types/03-string/2-check-spam/solution.md
+++ b/1-js/05-data-types/03-string/2-check-spam/solution.md
@@ -1,6 +1,6 @@
 为了使搜索不区分大小写，我们将字符串改为小写，然后搜索：
 
-```js run
+```js run demo
 function checkSpam(str) {
   let lowerStr = str.toLowerCase();
 

--- a/1-js/05-data-types/03-string/3-truncate/_js.view/test.js
+++ b/1-js/05-data-types/03-string/3-truncate/_js.view/test.js
@@ -1,5 +1,5 @@
 describe("truncate", function() {
-  it("truncate the long string to the given lenth (including the ellipsis)", function() {
+  it("truncate the long string to the given length (including the ellipsis)", function() {
     assert.equal(
       truncate("What I'd like to tell on this topic is:", 20),
       "What I'd like to te…"

--- a/1-js/05-data-types/03-string/3-truncate/solution.md
+++ b/1-js/05-data-types/03-string/3-truncate/solution.md
@@ -1,11 +1,10 @@
 最大长度必须是 `maxlength`，因此为了给省略号留空间我们需要缩短它。
 
-注意省略号实际上有一个 unicode 字符，而不仅仅是三个点。
+请注意，省略号实际上有一个单独的 unicode 字符，而不是三个点。
 
-```js run
+```js run demo
 function truncate(str, maxlength) {
-  return (str.length > maxlength) ? 
+  return (str.length > maxlength) ?
     str.slice(0, maxlength - 1) + '…' : str;
 }
 ```
-

--- a/1-js/05-data-types/03-string/3-truncate/task.md
+++ b/1-js/05-data-types/03-string/3-truncate/task.md
@@ -2,11 +2,11 @@ importance: 5
 
 ---
 
-# 缩短文本
+# 截断文本
 
-创建函数 `truncate(str, maxlength)` 来检查 `str` 的长度，如果超过 `maxlength`—— 应使用 `"…"` 来代替 `str` 的皆为部分，长度仍然等于 `maxlength`。
+创建函数 `truncate(str, maxlength)` 来检查 `str` 的长度，如果超过 `maxlength` —— 应使用 `"…"` 来代替 `str` 的结尾部分，长度仍然等于 `maxlength`。
 
-函数的结果应该是缩短的文本（如果有需要的话）。
+函数的结果应该是截断后的文本（如果需要的话）。
 
 例如：
 

--- a/1-js/05-data-types/03-string/4-extract-currency/task.md
+++ b/1-js/05-data-types/03-string/4-extract-currency/task.md
@@ -8,7 +8,7 @@ importance: 4
 
 创建函数 `extractCurrencyValue(str)` 从字符串中提取数值并返回。
 
-比如：
+例如：
 
 ```js
 alert( extractCurrencyValue('$120') === 120 ); // true

--- a/1-js/05-data-types/03-string/article.md
+++ b/1-js/05-data-types/03-string/article.md
@@ -108,7 +108,7 @@ alert( "\u{1F60D}" ); // 😍，笑脸符号（另一个长 unicode）
 alert( 'I*!*\'*/!*m the Walrus!' ); // *!*I'm*/!* the Walrus!
 ```
 
-正如你所看到的，我们必须用内部引号前加上反斜杠 `\'`，否则它将表示字符串结束。
+正如你所看到的，我们必须在内部引号前加上反斜杠 `\'`，否则它将表示字符串结束。
 
 当然，只有与外部闭合引号相同的引号才需要转义。因此，作为一个更优雅的解决方案，我们可以改用双引号或者反引号：
 
@@ -172,7 +172,7 @@ alert( str.charAt(1000) ); // ''（空字符串）
 
 ```js run
 for (let char of "Hello") {
-  alert(char); // H,e,l,l,o（char 变为  "H"，然后是 "e"，然后是 "l" 等）
+  alert(char); // H,e,l,l,o（char 变为 "H"，然后是 "e"，然后是 "l" 等）
 }
 ```
 
@@ -254,7 +254,7 @@ alert( str.indexOf('id', 2) ) // 12
 ```js run
 let str = 'As sly as a fox, as strong as an ox';
 
-let target = 'as'; // 让我们查看一下
+let target = 'as'; // 这是我们要查找的目标
 
 let pos = 0;
 while (true) {
@@ -280,25 +280,25 @@ while ((pos = str.indexOf(target, pos + 1)) != -1) {
 */!*
 ```
 
-```smart header="`str.lastIndexOf(subStr, pos)`"
-还有一个类似的方法 [str.lastIndexOf(subStr, pos)](mdn:js/String/lastIndexOf)，他从字符串的末尾开始搜索。
+```smart header="`str.lastIndexOf(substr, pos)`"
+还有一个类似的方法 [str.lastIndexOf(substr, position)](mdn:js/String/lastIndexOf)，它从字符串的末尾开始搜索到开头。
 
-它会以相反的顺序列出事件。
+它会以相反的顺序列出这些事件。
 ```
 
-在 `if` 测试中 `indexOf` 有一点不方便。我们不可以把它放在这样的 `if` 中：
+在 `if` 测试中 `indexOf` 有一点不方便。我们不能像这样把它放在 `if` 中：
 
 ```js run
 let str = "Widget with id";
 
 if (str.indexOf("Widget")) {
-    alert("We found it"); // doesn't work!
+    alert("We found it"); // 不工作！
 }
 ```
 
-上述示例中的 `alert` 不会显示，因为 `str.indexOf("Widget")` 返回 `0`（意思是它在起始位置查找匹配）。是的，但是  `if` 认为 `0` 应该是 `false`。
+上述示例中的 `alert` 不会显示，因为 `str.indexOf("Widget")` 返回 `0`（意思是它在起始位置就查找到了匹配项）。是的，但是 `if` 认为 `0` 表示 `false`。
 
-因此我们实际上是从 `-1` 开始的，就像这样：
+因此我们应该检查 `-1`，像这样：
 
 ```js run
 let str = "Widget with id";
@@ -306,15 +306,15 @@ let str = "Widget with id";
 *!*
 if (str.indexOf("Widget") != -1) {
 */!*
-    alert("We found it"); // 现在运行了！
+    alert("We found it"); // 现在工作了！
 }
 ```
 
 #### 按位（bitwise）NOT 技巧
 
-这里使用的一个老技巧是 [bitwise NOT](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_NOT) `~` 运算符。它将该数字转换为 32-bit 整数（如果存在，则删除小数部分），然后反转其二进制表示中的所有位。
+这里使用的一个老技巧是 [bitwise NOT](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_Operators#Bitwise_NOT) `~` 运算符。它将数字转换为 32-bit 整数（如果存在小数部分，则删除小数部分），然后对其二进制表示形式中的所有位均取反。
 
-在实际使用中这表示对于 32-bit 整数 `~n` 的意思与 `-(n+1)` 完全一样。
+实际上，这意味着一件很简单的事儿：对于 32-bit 整数，`~n` 等于 `-(n+1)`。
 
 例如：
 
@@ -327,9 +327,9 @@ alert( ~-1 ); // 0，和 -(-1+1) 相同
 */!*
 ```
 
-正如我们看到这样，只有当 `n == -1` 时，`~n` 才为零（that's for any 32-bit signed integer `n`）。
+正如我们看到这样，只有当 `n == -1` 时，`~n` 才为零（适用于任何 32-bit 带符号的整数 `n`）。
 
-因此，测试 `if ( ~str.indexOf("...") )` 为真仅当 `indexOf` 的结果不是 `-1`。换句话说，当有匹配时。
+因此，仅当 `indexOf` 的结果不是 `-1` 时，检查 `if ( ~str.indexOf("...") )` 才为真。换句话说，当有匹配时。
 
 人们用它来简写 `indexOf` 检查：
 
@@ -345,15 +345,15 @@ if (~str.indexOf("Widget")) {
 
 只要记住：`if (~str.indexOf(...))` 读作 "if found"。
 
-确切地说，由于 `~` 运算符将大数字截断为 32 位，因此存在给出 `0` 的其他数字，最小的数字是 `~4294967295=0`。这使得这种检查只有在字符串不长的情况下才是正确的。
+确切地说，由于 `~` 运算符将大数字截断为 32 位，因此存在给出 `0` 的其他数字，最小的数字是 `~4294967295=0`。这使得这种检查只有在字符串没有那么长的情况下才是正确的。
 
-现在我们可以只能在旧的代码中看到这个技巧，因为现代 JavaScript 提供了 `.includes` 方法（见下文）。
+现在我们只会在旧的代码中看到这个技巧，因为现代 JavaScript 提供了 `.includes` 方法（见下文）。
 
-### includes, startsWith, endsWith
+### includes，startsWith，endsWith
 
-更现代的方法 [str.includes(substr, pos)](mdn:js/String/includes) 取决于 `str` 是否包含 `substr` 来返回 `true/false`。
+更现代的方法 [str.includes(substr, pos)](mdn:js/String/includes) 根据 `str` 中是否包含 `substr` 来返回 `true/false`。
 
-如果我们需要测试匹配，这是正确的选择，但不需要它的位置：
+如果我们需要检测匹配，但不需要它的位置，那么这是正确的选择：
 
 ```js run
 alert( "Widget with id".includes("Widget") ); // true
@@ -361,18 +361,18 @@ alert( "Widget with id".includes("Widget") ); // true
 alert( "Hello".includes("Bye") ); // false
 ```
 
-`str.includes` 的第二个可选参数从以下位置开始搜索位置：
+`str.includes` 的第二个可选参数是开始搜索的起始位置：
 
 ```js run
 alert( "Midget".includes("id") ); // true
-alert( "Midget".includes("id", 3) ); // false, 位置 3 没有“id”
+alert( "Midget".includes("id", 3) ); // false, 从位置 3 开始没有 "id"
 ```
 
-方法 [str.startsWith](mdn:js/String/startsWith) 和 [str.endsWith](mdn:js/String/endsWith) 完全按照它们所说的执行：
+方法 [str.startsWith](mdn:js/String/startsWith) 和 [str.endsWith](mdn:js/String/endsWith) 的功能与其名称所表示的意思相同：
 
 ```js run
-alert( "Widget".startsWith("Wid") ); // true，“Widget”以“Wid”开始
-alert( "Widget".endsWith("get") ); // true，“Widget”以“get”结束
+alert( "Widget".startsWith("Wid") ); // true，"Widget" 以 "Wid" 开始
+alert( "Widget".endsWith("get") ); // true，"Widget" 以 "get" 结束
 ```
 
 ## 获取子字符串
@@ -380,34 +380,34 @@ alert( "Widget".endsWith("get") ); // true，“Widget”以“get”结束
 JavaScript 中有三种获取字符串的方法：`substring`、`substr` 和 `slice`。
 
 `str.slice(start [, end])`
-: 返回从 `start` 到（但不包括）`end` 的字符串部分。
+: 返回字符串从 `start` 到（但不包括）`end` 的部分。
 
     例如：
 
     ```js run
     let str = "stringify";
-    alert( str.slice(0, 5) ); // 'strin', 从 0 到 5 的子字符串（不包括 5）
-    alert( str.slice(0, 1) ); // 's', 从 0 到 1，但不包括 1，所以只有在 0 的字符
+    alert( str.slice(0, 5) ); // 'strin'，从 0 到 5 的子字符串（不包括 5）
+    alert( str.slice(0, 1) ); // 's'，从 0 到 1，但不包括 1，所以只有在 0 处的字符
     ```
 
-    如果没有第二个参数，`slice` 运行到字符串末尾：
+    如果没有第二个参数，`slice` 会一直运行到字符串末尾：
 
     ```js run
     let str = "st*!*ringify*/!*";
     alert( str.slice(2) ); // 从第二个位置直到结束
     ```
 
-    `start/end` 也有可能是负值。它们的意思是位置从字符串结尾计算：
+    `start/end` 也有可能是负值。它们的意思是起始位置从字符串结尾计算：
 
     ```js run
     let str = "strin*!*gif*/!*y";
 
     // 从右边的第四个位置开始，在右边的第一个位置结束
-    alert( str.slice(-4, -1) ); // */!
+    alert( str.slice(-4, -1) ); // 'gif'
     ```
 
 `str.substring(start [, end])`
-: 返回 `start` 和 `end` **之间**的字符串部分。
+: 返回字符串在 `start` 和 `end` **之间** 的部分。
 
     这与 `slice` 几乎相同，但它允许 `start` 大于 `end`。
 
@@ -416,12 +416,12 @@ JavaScript 中有三种获取字符串的方法：`substring`、`substr` 和 `sl
     ```js run
     let str = "st*!*ring*/!*ify";
 
-    // 这些对于子串是相同的
+    // 这些对于 substring 是相同的
     alert( str.substring(2, 6) ); // "ring"
     alert( str.substring(6, 2) ); // "ring"
 
-    // ……但除了 slice：
-    alert( str.slice(2, 6) ); // "ring"（相同字符串）
+    // ……但对 slice 是不同的：
+    alert( str.slice(2, 6) ); // "ring"（一样）
     alert( str.slice(6, 2) ); // ""（空字符串）
 
     ```
@@ -429,32 +429,32 @@ JavaScript 中有三种获取字符串的方法：`substring`、`substr` 和 `sl
     不支持负参数（不像 slice），它们被视为 `0`。
 
 `str.substr(start [, length])`
-:  从 `start` 开始返回给定 `length` 的字符串部分。
+: 返回字符串从 `start` 开始的给定 `length` 的部分。
 
     与以前的方法相比，这个允许我们指定 `length` 而不是结束位置：
 
     ```js run
     let str = "st*!*ring*/!*ify";
-    alert( str.substr(2, 4) ); // 环，从第二位获得 4 个字符
+    alert( str.substr(2, 4) ); // 'ring'，从位置 2 开始，获取 4 个字符
     ```
 
     第一个参数可能是负数，从结尾算起：
 
     ```js run
     let str = "strin*!*gi*/!*fy";
-    alert( str.substr(-4, 2) ); // gi，从第 4 位获得 2 个字符
+    alert( str.substr(-4, 2) ); // 'gi'，从第 4 位获取 2 个字符
     ```
 
 我们回顾一下这些方法，以免混淆：
 
-| 方法 | 选择方式…… | 负号参数 |
+| 方法 | 选择方式…… | 负值参数 |
 |--------|-----------|-----------|
-| `slice(start, end)` | 从 `start` 到 `end` (不含 `end`) | 允许 |
-| `substring(start, end)` | `start` 与 `end` 之间 | 负值代表 `0` |
+| `slice(start, end)` | 从 `start` 到 `end`（不含 `end`）| 允许 |
+| `substring(start, end)` | `start` 与 `end` 之间（包括 `start` 和 `end`） | 负值代表 `0` |
 | `substr(start, length)` | 从 `start` 开始获取长为 `length` 的字符串 | 允许 `start` 为负数 |
 
 ```smart header="使用哪一个？"
-他们可以完成这项工作，形式上，`substr` 有一个小缺点：它不是在 JavaScript 核心规范中描述的，而是在附录 B 中，它涵盖了主要由于历史原因而存在的浏览器特性。因此，非浏览器环境可能无法支持它。但实际上它在任何地方都有效。
+它们可以完成这项工作。形式上，`substr` 有一个小缺点：它不是在 JavaScript 核心规范中描述的，而是在附录 B 中，它涵盖了主要由于历史原因而存在的仅浏览器特性。因此，非浏览器环境可能无法支持它。但实际上它在任何地方都有效。
 
 相较于其他两个变体，`slice` 稍微灵活一些，它允许以负值作为参数并且写法更简短。因此仅仅记住这三种方法中的 `slice` 就足够了。
 ```
@@ -471,17 +471,17 @@ JavaScript 中有三种获取字符串的方法：`substring`、`substr` 和 `sl
     alert( 'a' > 'Z' ); // true
     ```
 
-2. 带有指示性标记的字母“不正常”：
+2. 带变音符号的字母存在“乱序”的情况：
 
     ```js run
     alert( 'Österreich' > 'Zealand' ); // true
     ```
 
-    如果我们对这些国名进行排序，可能会导致奇怪的结果。通常，人们会期望 `Zealand` 在名单中的 `Österreich` 之后出现。
+    如果我们对这些国家名进行排序，可能会导致奇怪的结果。通常，人们会期望 `Zealand` 在名单中的 `Österreich` 之后出现。
 
 为了明白发生了什么，我们回顾一下在 JavaScript 中字符串的内部表示。
 
-所有的字符串都使用 [UTF-16](https://en.wikipedia.org/wiki/UTF-16) 编码。即：每个字符都有相应的数字代码。有特殊的方法可以获取代码表示的字符，以及字符对应的代码。
+所有的字符串都使用 [UTF-16](https://en.wikipedia.org/wiki/UTF-16) 编码。即：每个字符都有对应的数字代码。有特殊的方法可以获取代码表示的字符，以及字符对应的代码。
 
 `str.codePointAt(pos)`
 : 返回在 `pos` 位置的字符代码 :
@@ -506,7 +506,7 @@ JavaScript 中有三种获取字符串的方法：`substring`、`substr` 和 `sl
     alert( '\u005a' ); // Z
     ```
 
-现在我们看一下代码 `65..220` 的字符（拉丁字母和一些额外的字符），方法是创建一个字符串：
+现在我们看一下代码为 `65..220` 的字符（拉丁字母和一些额外的字符），方法是创建一个字符串：
 
 ```js run
 let str = '';
@@ -523,7 +523,7 @@ alert( str );
 
 现在很明显为什么 `a > Z`。
 
-字符通过数字代码进行比较。越大的代码意味着字符越大。`a`（97）的代码大于 `Z`（90）。
+字符通过数字代码进行比较。越大的代码意味着字符越大。`a`（97）的代码大于 `Z`（90）的代码。
 
 - 所有小写字母追随在大写字母之后，因为它们的代码更大。
 - 一些像 `Ö` 的字母与主要字母表不同。这里，它的代码比任何从 `a` 到 `z` 的代码都要大。
@@ -534,14 +534,14 @@ alert( str );
 
 因此浏览器需要知道要比较的语言。
 
-幸运地是，所有现代浏览器（IE10- 需要额外的库 [Intl.JS](https://github.com/andyearnshaw/Intl.js/)) 支持国际化标准 [ECMA 402](http://www.ecma-international.org/ecma-402/1.0/ECMA-402.pdf)。
+幸运的是，所有现代浏览器（IE10- 需要额外的库 [Intl.JS](https://github.com/andyearnshaw/Intl.js/)) 都支持国际化标准 [ECMA 402](http://www.ecma-international.org/ecma-402/1.0/ECMA-402.pdf)。
 
 它提供了一种特殊的方法来比较不同语言的字符串，遵循它们的规则。
 
 调用 [str.localeCompare(str2)](mdn:js/String/localeCompare) 会根据语言规则返回一个整数，这个整数能表明 `str` 是否在 `str2` 前，后或者等于它：
 
-- 如果 `str` 小于 `str2` 返回负数，例如，`str` 在 `str2` 前。
-- 如果 `str` 大于 `str2` 返回正数，例如，`str` 在 `str2` 后。
+- 如果 `str` 小于 `str2` 则返回负数。
+- 如果 `str` 大于 `str2` 则返回正数。
 - 如果它们相等则返回 `0`。
 
 例如：
@@ -550,12 +550,12 @@ alert( str );
 alert( 'Österreich'.localeCompare('Zealand') ); // -1
 ```
 
-这个方法实际上在[文档](mdn:js/String/localeCompare)中指定了两个额外的参数，它允许它指定语言（默认从环境中获取，字符顺序视语言不同而不同）并设置诸如区别大小之类的附加规则，或应该处理将 `"a"` 和 `"á"` 看作相等情况等。
+这个方法实际上在 [文档](mdn:js/String/localeCompare) 中指定了两个额外的参数，这两个参数允许它指定语言（默认语言从环境中获取，字符顺序视语言不同而不同）并设置诸如区别大小之类的附加规则，或应该将 `"a"` 和 `"á"` 看作相等情况等。
 
 ## 内部，Unicode
 
-```warn header="高级内容"
-这部分会深入字符串内部。如果你计划处理表情符号、罕见的象形文字字符或其他罕见符号，这些知识会对你有用。
+```warn header="进阶内容"
+这部分会深入字符串内部。如果你计划处理 emoji、罕见的数学或象形文字或其他罕见的符号，这些知识会对你有用。
 
 如果你不打算支持它们，你可以跳过这一部分。
 ```
@@ -564,7 +564,7 @@ alert( 'Österreich'.localeCompare('Zealand') ); // -1
 
 所有常用的字符都是一个 2 字节的代码。大多数欧洲语言，数字甚至大多数象形文字中的字母都有 2 字节的表示形式。
 
-但 2 字节只允许 65536 个组合，这对于每个可能的符号都是不够的。所以稀有的符号被称为“代理对”的一对 2 字节符号编码。
+但 2 字节只允许 65536 个组合，这对于表示每个可能的符号是不够的。所以稀有的符号被称为“代理对”的一对 2 字节的符号编码。
 
 这些符号的长度是 `2`：
 
@@ -574,11 +574,11 @@ alert( '😂'.length ); // 2，笑哭表情
 alert( '𩷶'.length ); // 2，罕见的中国象形文字
 ```
 
-注意，代理对在 JavaScript 被创建时并不存在，因此无法被语言正确代理。
+注意，代理对在 JavaScript 被创建时并不存在，因此无法被编程语言正确处理！
 
 我们实际上在上面的每个字符串中都有一个符号，但 `length` 显示长度为 `2`。
 
-`String.fromCodePoint` 和 `str.codePointAt` 是几种处理代理对的少数方法。它们最近才出现在语言中。在它们之前，只有 [String.fromCharCode](mdn:js/String/fromCharCode) 和 [str.charCodeAt](mdn:js/String/charCodeAt)。这些方法实际上与 `fromCodePoint/codePointAt` 相同，但是不适用于代理对。
+`String.fromCodePoint` 和 `str.codePointAt` 是几种处理代理对的少数方法。它们最近才出现在编程语言中。在它们之前，只有 [String.fromCharCode](mdn:js/String/fromCharCode) 和 [str.charCodeAt](mdn:js/String/charCodeAt)。这些方法实际上与 `fromCodePoint/codePointAt` 相同，但是不适用于代理对。
 
 获取符号可能会非常麻烦，因为代理对被认为是两个字符：
 
@@ -587,26 +587,26 @@ alert( '𝒳'[0] ); // 奇怪的符号……
 alert( '𝒳'[1] ); // ……代理对的一块
 ```
 
-请注意，代理对的各部分没有任何意义。因此，上述示例中的 alert 显示实际上并没有用。
+请注意，代理对的各部分没有任何意义。因此，上述示例中的 alert 显示的实际上是垃圾信息。
 
-技术角度来说，代理对也是可以通过它们的代码检测到：如果一个字符的代码间隔为 `0xd800..0xdbff`，那么它是代理对的第一部分。下一个字符（第二部分）必须在时间间隔 `0xdc00..0xdfff` 中。这些间隔仅有标准的代理对保留。
+技术角度来说，代理对也是可以通过它们的代码检测到的：如果一个字符的代码在 `0xd800..0xdbff` 范围内，那么它是代理对的第一部分。下一个字符（第二部分）必须在 `0xdc00..0xdfff` 范围中。这些范围是按照标准专门为代理对保留的。
 
 在上述示例中：
 
 ```js run
-// charCodeAt is not surrogate-pair aware, so it gives codes for parts
+// charCodeAt 不理解代理对，所以它给出了代理对的代码
 
-alert( '𝒳'.charCodeAt(0).toString(16) ); // d835, 在 0xd800 和 0xdbff 之间
+alert( '𝒳'.charCodeAt(0).toString(16) ); // d835，在 0xd800 和 0xdbff 之间
 alert( '𝒳'.charCodeAt(1).toString(16) ); // dcb3, 在 0xdc00 和 0xdfff 之间
 ```
 
-本章节后面的 <info:iterable> 中可以找到更多处理代理对的方法。也可能有特殊的库，这里没有什么足够好的建议。
+本章节后面的 <info:iterable> 章节中，你可以找到更多处理代理对的方法。可能也专门的库，这里没有什么足够好的建议了。
 
 ### 变音符号与规范化
 
-在许多语言中，有一些符号是由上面/下面有标记的基本字符组成的。
+在许多语言中，都有一些由基本字符组成的符号，在其上方/下方有一个标记。
 
-例如，字母 `a` 可以是基本字符：`àáâäãåā`。最常见的“复合”字符在 UTF-16 表中有自己的代码。但不是全部，因为可能的组合太多。
+例如，字母 `a` 可以是 `àáâäãåā` 的基本字符。最常见的“复合”字符在 UTF-16 表中都有自己的代码。但不是全部，因为可能的组合太多。
 
 为了支持任意组合，UTF-16 允许我们使用多个 unicode 字符：基本字符紧跟“装饰”它的一个或多个“标记”字符。
 
@@ -618,7 +618,7 @@ alert( 'S\u0307' ); // Ṡ
 
 如果我们需要在字母上方（或下方）添加额外的标记 —— 没问题，只需要添加必要的标记字符即可。
 
-例如，如果我们追加一个字符 "dot below"（代码 `\u0323`），那么我们将得到“S 点以上和以下的”：`Ṩ`。
+例如，如果我们追加一个字符 "dot below"（代码 `\u0323`），那么我们将得到“S 上面和下面都有点”的字符：`Ṩ`。
 
 例如：
 
@@ -631,8 +631,8 @@ alert( 'S\u0307\u0323' ); // Ṩ
 例如：
 
 ```js run
-let s1 = 'S\u0307\u0323'; // Ṩ，s + 上点 + 下点
-let s2 = 'S\u0323\u0307'; // Ṩ，s + 下点 + 上点
+let s1 = 'S\u0307\u0323'; // Ṩ，S + 上点 + 下点
+let s2 = 'S\u0323\u0307'; // Ṩ，S + 下点 + 上点
 
 alert( `s1: ${s1}, s2: ${s2}` );
 
@@ -647,7 +647,7 @@ alert( s1 == s2 ); // false，尽管字符看起来相同（?!）
 alert( "S\u0307\u0323".normalize() == "S\u0323\u0307".normalize() ); // true
 ```
 
-我们遇到的有趣现象是实际上 `normalize()` 将一个由 3 个字符组成的序列合并为一个：`\u1e68`（S 有两个点）。
+有趣的是，在实际情况下，`normalize()` 实际上将一个由 3 个字符组成的序列合并为一个：`\u1e68`（S 有两个点）。
 
 ```js run
 alert( "S\u0307\u0323".normalize().length ); // 1
@@ -655,14 +655,14 @@ alert( "S\u0307\u0323".normalize().length ); // 1
 alert( "S\u0307\u0323".normalize() == "\u1e68" ); // true
 ```
 
-事实上，情况并非总是如此，因为符号 `Ṩ` “常用”，所以 UTF-16 创建者把它包含在主表中并给了它代码。
+事实上，情况并非总是如此，因为符号 `Ṩ` 是“常用”的，所以 UTF-16 创建者把它包含在主表中并给它了对应的代码。
 
 如果你想了解更多关于规范化规则和变体的信息 —— 它们在 Unicode 标准附录中有详细描述：[Unicode 规范化形式](http://www.unicode.org/reports/tr15/)，但对于大多数实际目的来说，本文的内容就已经足够了。
 
 ## 总结
 
-- 有 3 种类型的引号。反引号允许字符串跨越多行并可以在 `${…}` 中嵌入表达式。
-- JavaScript 中的字符串使用 UTF-16 进行编码。
+- 有 3 种类型的引号。反引号允许字符串跨越多行并可以使用 `${…}` 在字符串中嵌入表达式。
+- JavaScript 中的字符串使用的是 UTF-16 编码。
 - 我们可以使用像 `\n` 这样的特殊字符或通过使用 `\u...` 来操作它们的 unicode 进行字符插入。 
 - 获取字符时，使用 `[]`。
 - 获取子字符串，使用 `slice` 或 `substring`。
@@ -670,10 +670,10 @@ alert( "S\u0307\u0323".normalize() == "\u1e68" ); // true
 - 查找子字符串时，使用 `indexOf` 或 `includes/startsWith/endsWith` 进行简单检查。
 - 根据语言比较字符串时使用 `localeCompare`，否则将按字符代码进行比较。
 
-字符串还有其他几种有用的方法：
+还有其他几种有用的字符串方法：
 
 - `str.trim()` —— 删除字符串前后的空格 ("trims")。
 - `str.repeat(n)` —— 重复字符串 `n` 次。
-- ……更多内容细节参见[手册](mdn:js/String)。
+- ……更多内容细节请参见 [手册](mdn:js/String)。
 
-字符串还具有用正则表达式执行搜索/替换的方法。但这个话题很大，因此我们单独将它放在 <info:regular-expressions> 章节讨论。
+字符串还具有使用正则表达式进行搜索/替换的方法。但这个话题很大，因此我们将在本教程中单独的 <info:regular-expressions> 章节中进行讨论。


### PR DESCRIPTION
#### 目标章节：1-js/05-data-types/03-string/

#### 当前上游最新 commit：https://github.com/javascript-tutorial/en.javascript.info/commit/10c7807f49122f475f7cda5d07a324247091c080

#### 所做更改如下：

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | https://github.com/javascript-tutorial/en.javascript.info/commit/6f7ec123587f070ae1e16a11148135e604429324 | 更新译文
