### PR TITLE
Update translation of 1-js/09-classes/05-extend-natives

### DIFF
--- a/1-js/09-classes/05-extend-natives/article.md
+++ b/1-js/09-classes/05-extend-natives/article.md
@@ -68,7 +68,7 @@ alert(filteredArr.isEmpty()); // Error: filteredArr.isEmpty is not a function
 其他集合，例如 `Map` 和 `Set` 的工作方式类似。它们也使用 `Symbol.species`。
 ```
 
-### 内建类没有静态方法继承 No static inheritance in built-ins
+### 内建类没有静态方法继承
 
 内建对象有它们自己的静态方法，例如 `Object.keys`，`Array.isArray` 等。
 
@@ -76,14 +76,14 @@ alert(filteredArr.isEmpty()); // Error: filteredArr.isEmpty is not a function
 
 通常，当一个类扩展另一个类时，静态方法和非静态方法都会被继承。这已经在 [](info:static-properties-methods#statics-and-inheritance) 中详细地解释过了。
 
-但内建类却是一个例外。它们相互间不继承静态属性和方法。
+但内建类却是一个例外。它们相互间不继承静态方法。
 
-比如，`Array` 和 `Data` 都是继承自 `Object`，所以它们的实例都有来自 `Object.prototype` 的方法，但是 `Array.[[Prototype]]` 不指向 `Object`，所以它们没有例如 `Array.keys()`(或者 `Data.keys()`)的静态方法。
+例如，`Array` 和 `Data` 都继承自 `Object`，所以它们的实例都有来自 `Object.prototype` 的方法。但 `Array.[[Prototype]]` 并不指向 `Object`，所以它们没有例如 `Array.keys()`（或 `Data.keys()`）这些静态方法。
 
-这里有一张 `Date` 和 `Object` 结构关系的图片
+这里有一张 `Date` 和 `Object` 的结构关系图：
 
 ![](object-date-inheritance.svg)
 
-如你所见，`Date` 和 `Object` 之间没有连结。`Object` 和 `Date` 都是独立存在的。`Date.prototype` 继承自 `Object.prototype`，但也仅此而已。
+正如你所看到的，`Date` 和 `Object` 之间没有连结。它们是独立的，只有 `Date.prototype` 继承自 `Object.prototype`，仅此而已。
 
-与我们了解的继承（`extends`）相比，这是内置对象之间的继承的一个非常重要的区别。
+与我们通过 `extends` 获得的继承相比，这是内建对象之间的继承的一个重要的区别。

--- a/1-js/09-classes/05-extend-natives/article.md
+++ b/1-js/09-classes/05-extend-natives/article.md
@@ -1,9 +1,9 @@
-# 继承内置类
 
-内置的类比如 `Array`，`Map` 等也都是可以继承的。
+# 扩展内建类
 
-比如，这里有一个 `PowerArray` 继承自原生的 `Array`： 
+内建的类，例如 `Array`，`Map` 等也都是可以扩展的（extendable）。
 
+例如，这里有一个继承自原生 `Array` 的类 `PowerArray`： 
 
 ```js run
 // 给 PowerArray 新增了一个方法（可以增加更多）

--- a/1-js/09-classes/05-extend-natives/article.md
+++ b/1-js/09-classes/05-extend-natives/article.md
@@ -86,4 +86,4 @@ alert(filteredArr.isEmpty()); // Error: filteredArr.isEmpty is not a function
 
 正如你所看到的，`Date` 和 `Object` 之间没有连结。它们是独立的，只有 `Date.prototype` 继承自 `Object.prototype`，仅此而已。
 
-与我们通过 `extends` 获得的继承相比，这是内建对象之间的继承的一个重要的区别。
+与我们所了解的通过 `extends` 获得的继承相比，这是内建对象之间的继承的一个重要的区别。

--- a/1-js/09-classes/05-extend-natives/article.md
+++ b/1-js/09-classes/05-extend-natives/article.md
@@ -86,4 +86,4 @@ alert(filteredArr.isEmpty()); // Error: filteredArr.isEmpty is not a function
 
 正如你所看到的，`Date` 和 `Object` 之间没有连结。它们是独立的，只有 `Date.prototype` 继承自 `Object.prototype`，仅此而已。
 
-与我们所了解的通过 `extends` 获得的继承相比，这是内建对象之间的继承的一个重要的区别。
+与我们所了解的通过 `extends` 获得的继承相比，这是内建对象之间继承的一个重要区别。

--- a/1-js/09-classes/05-extend-natives/article.md
+++ b/1-js/09-classes/05-extend-natives/article.md
@@ -21,22 +21,20 @@ alert(filteredArr); // 10, 50
 alert(filteredArr.isEmpty()); // false
 ```
 
-请注意一个非常有趣的事情。内置的方法比如 `filter`，`map` 等 -- 返回的正是子类 `PowerArray` 的新对象。它们内部通过对象的 `constructor` 属性实现了这一功能。
+请注意一个非常有趣的事儿。内建的方法例如 `filter`，`map` 等 — 返回的正是子类 `PowerArray` 的新对象。它们内部使用了对象的 `constructor` 属性来实现这一功能。
 
 在上面的例子中，
 ```js
 arr.constructor === PowerArray
 ```
 
+当 `arr.filter()` 被调用时，它的内部使用的是 `arr.constructor` 来创建新的结果数组，而不是使用原生的 `Array`。这真的很酷，因为我们可以在结果数组上继续使用 `PowerArray` 的方法。
 
+甚至，我们可以定制这种行为。
 
-所以当 `arr.filter()` 被调用的时候，它在内部使用的是 `new PowerArray` 的返回值来创建新数组，而不是原生的 `Array`。这真的很酷，因为我们可以在返回值中继续使用 `PowerArray` 的方法。
+我们可以给这个类添加一个特殊的静态 getter `Symbol.species`。如果存在，则应返回 JavaScript 在内部用来在 `map` 和 `filter` 等方法中创建新实体的 `constructor`。
 
-更重要的是，我们可以定制这种行为。
-
-我们可以给这个类增加一个特殊的静态 getter `Symbol.species`。如果存在，则应返回 JavaScript 内部用来在 map，filter 等方法中创建新实体的构造函数 (constructor)。
-
-如果我们希望类似 `map` 或者 `filter` 这样的内置方法返回常规的数组，我们应该在 `Symbol.species` 中返回 `Array`，就像这样：
+如果我们希望像 `map` 或 `filter` 这样的内建方法返回常规数组，我们可以在 `Symbol.species` 中返回 `Array`，就像这样：
 
 ```js run
 class PowerArray extends Array {
@@ -45,7 +43,7 @@ class PowerArray extends Array {
   }
 
 *!*
-  // 内置方法会使用这个作为构造函数 (constructor)
+  // 内建方法将使用这个作为 constructor
   static get [Symbol.species]() {
     return Array;
   }
@@ -55,30 +53,30 @@ class PowerArray extends Array {
 let arr = new PowerArray(1, 2, 5, 10, 50);
 alert(arr.isEmpty()); // false
 
-// filter 使用 arr.constructor[Symbol.species] 作为构造函数 (constructor) 创建新数组
+// filter 使用 arr.constructor[Symbol.species] 作为 constructor 创建新数组
 let filteredArr = arr.filter(item => item >= 10);
 
 *!*
-// filteredArr 不是 PowerArray, 而是 Array
+// filteredArr 不是 PowerArray，而是 Array
 */!*
 alert(filteredArr.isEmpty()); // Error: filteredArr.isEmpty is not a function
 ```
 
-如你所见，现在 `.filter` 返回 `Array`。所以子类 `PowerArray` 的功能不再传递给 `filteredArr`。
+正如你所看到的，现在 `.filter` 返回 `Array`。所以扩展的功能不再传递。
 
-```smart header="其他集合也同样适用"
-其他的集合比如 `Map` 和 `Set` 也同样适用，它们也可以使用 `Symbol.species`.
+```smart header="其他集合的工作方式类似"
+其他集合，例如 `Map` 和 `Set` 的工作方式类似。它们也使用 `Symbol.species`。
 ```
 
-### 内置类没有静态方法继承
+### 内建类没有静态方法继承 No static inheritance in built-ins
 
-内置对象有它们自己的静态方法，比如 `Object.keys`，`Array.isArray` 等。
+内建对象有它们自己的静态方法，例如 `Object.keys`，`Array.isArray` 等。
 
-如我们所知道的，原生的类互相继承。比如，`Array` 继承自 `Object`。
+如我们所知道的，原生的类互相扩展。例如，`Array` 扩展自 `Object`。
 
-正常来说，当一个类继承自其他类的时候，静态方法和非静态方法都会被继承。这已经在这篇文章 [](info:static-properties-methods#statics-and-inheritance) 中详尽地解释过了。
+通常，当一个类扩展另一个类时，静态方法和非静态方法都会被继承。这已经在 [](info:static-properties-methods#statics-and-inheritance) 中详细地解释过了。
 
-但内置类却是一个例外，它们相互间不继承静态属性和方法。
+但内建类却是一个例外。它们相互间不继承静态属性和方法。
 
 比如，`Array` 和 `Data` 都是继承自 `Object`，所以它们的实例都有来自 `Object.prototype` 的方法，但是 `Array.[[Prototype]]` 不指向 `Object`，所以它们没有例如 `Array.keys()`(或者 `Data.keys()`)的静态方法。
 


### PR DESCRIPTION
**目标章节**：1-js/09-classes/05-extend-natives

**当前上游最新 commit**：https://github.com/javascript-tutorial/en.javascript.info/commit/fcfef6a07842ed56144e04a80c3a24de049a952a

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | https://github.com/javascript-tutorial/en.javascript.info/commit/ad939bb80b49c06878916e7e05bd49380d67b5b4 | 更新译文
