### PR TITLE
Update translation of 1-js/11-async/05-promise-api

### DIFF
--- a/1-js/11-async/05-promise-api/article.md
+++ b/1-js/11-async/05-promise-api/article.md
@@ -220,7 +220,7 @@ Promise.race([
 
 ## Promise.resolve/reject
 
-在现代的代码中，很少会需要使用 `Promise.resolve` 和 `Promise.reject` 方法，因为 `async/await` 语法（我们会在 [稍后](info:async-await) 讲到）使它们变得有些过时了。
+在现代的代码中，很少需要使用 `Promise.resolve` 和 `Promise.reject` 方法，因为 `async/await` 语法（我们会在 [稍后](info:async-await) 讲到）使它们变得有些过时了。
 
 完整起见，以及考虑到那些出于某些原因而无法使用 `async/await` 的人，我们在这里对它们进行介绍。
 
@@ -234,22 +234,14 @@ Promise.race([
 let promise = new Promise(resolve => resolve(value));
 ```
 
-根据给定的 `value` 值返回 resolved promise。
+当一个函数被期望返回一个 promise 时，这个方法用于兼容性。（译注：这里的兼容性是指，我们直接从缓存中获取了当前操作的结果 `value`，但是期望返回的是一个 promise，所以可以使用 `Promise.resolve(value)` 将 `value` “封装”进 promise，以满足期望返回一个 promise 的这个需求。）
 
-等价于：
-
-```js
-let promise = new Promise(resolve => resolve(value));
-```
-
-当我们已经有一个 value 的时候，就会使用该方法，但希望将它“封装”进 promise。
-
-例如，下面的 `loadCached` 函数会获取 `url` 并记住结果，以便以后对同一 URL 进行调用时可以立即返回：
+例如，下面的 `loadCached` 函数获取（fetch）一个 URL 并记住其内容。以便将来对使用相同 URL 的调用，它能立即从缓存中获取先前的内容，但使用 `Promise.resolve` 创建了一个该内容的 promise，所以返回的值始终是一个 promise。
 
 ```js
+let cache = new Map();
+
 function loadCached(url) {
-  let cache = loadCached.cache || (loadCached.cache = new Map());
-
   if (cache.has(url)) {
 *!*
     return Promise.resolve(cache.get(url)); // (*)

--- a/1-js/11-async/05-promise-api/article.md
+++ b/1-js/11-async/05-promise-api/article.md
@@ -75,7 +75,7 @@ Promise.all(requests)
   .then(users => users.forEach(user => alert(user.name)));
 ```
 
-**如果任意一个 promise 被 reject，由 `Promise.all` 返回的 promise 就会立即 reject 这个 error。**
+**如果任意一个 promise 被 reject，由 `Promise.all` 返回的 promise 就会立即 reject，并且带有的就是这个 error。**
 
 例如：
 
@@ -89,14 +89,14 @@ Promise.all([
 ]).catch(alert); // Error: Whoops!
 ```
 
-这里的第二个 promise 在两秒内被 reject。这立即导致了对 `Promise.all` 的 reject。因此 `.catch` 被执行：reject 的错误成为整个 `Promise.all` 的结果。
+这里的第二个 promise 在两秒后 reject。这立即导致了 `Promise.all` 的 reject，因此 `.catch` 执行了：被 reject 的 error 成为了整个 `Promise.all` 的结果。
 
-```warn header="如果出现错误，其他 promise 就会被忽略"
-如果其中一个 promise 被 reject，`Promise.all` 就会立即被 reject 并忽略所有列表中其他的 promise。它们的结果也被忽略。
+```warn header="如果出现 error，其他 promise 将被忽略"
+如果其中一个 promise 被 reject，`Promise.all` 就会立即被 reject，完全忽略列表中其他的 promise。它们的结果也被忽略。
 
-例如，像上面例子中提到的那样，如果同时进行多个 `fetch` 操作，其中一个失败，其他的 `fetch` 操作仍然会继续执行，但是 `Promise.all` 会忽略它们。它们可能已经解决了某些问题，但是结果将会被忽略。
+例如，像上面那个例子，如果有多个同时进行的 `fetch` 调用，其中一个失败，其他的 `fetch` 操作仍然会继续执行，但是 `Promise.all` 将不会再关心（watch）它们。它们可能会 settle，但是它们的结果将被忽略。
 
-没有什么方法能取消 `Promise.all`，因为 promise 中没有 “cancellation” 这类概念。在 [其他章节](info:fetch-abort) 我们将会讨论可以“取消” promise 的 `AbortController`，但它不是 Promise API 的一部分。
+`Promise.all` 没有采取任何措施来取消它们，因为 promise 中没有“取消”的概念。在 [另一个章节](info:fetch-abort) 中，我们将介绍可以帮助我们解决这个问题（译注：指的是“取消” promise）的 `AbortController`，但它不是 Promise API 的一部分。
 ```
 
 ````smart header="`Promise.all(iterable)` 允许“迭代”中的非 promise（non-promise）的 \“常规\” 值"

--- a/1-js/11-async/05-promise-api/article.md
+++ b/1-js/11-async/05-promise-api/article.md
@@ -191,7 +191,7 @@ if(!Promise.allSettled) {
 
 在这段代码中，`promises.map` 获取输入值，并通过 `p => Promise.resolve(p)` 将输入值转换为 promise（以防传递了 non-promise），然后向每一个 promise 都添加 `.then` 处理器（handler）。
 
-这个处理器（handler）将成功的结果 `v` 转换为 `{state:'fulfilled', value:v}`，将 error `r` 转换为 `{state:'rejected', reason:r}`。这正是 `Promise.allSettled` 的格式。
+这个处理器（handler）将成功的结果 `value` 转换为 `{state:'fulfilled', value}`，将 error `reason` 转换为 `{state:'rejected', reason}`。这正是 `Promise.allSettled` 的格式。
 
 然后我们就可以使用 `Promise.allSettled` 来获取 **所有** 给定的 promise 的结果，即使其中一些被 reject。
 

--- a/1-js/11-async/05-promise-api/article.md
+++ b/1-js/11-async/05-promise-api/article.md
@@ -173,31 +173,31 @@ Promise.allSettled(urls.map(url => fetch(url)))
 
 ### Polyfill
 
-如果浏览器不支持 `Promise.allSettled`，使用 polyfill 很容易让其支持：
+如果浏览器不支持 `Promise.allSettled`，很容易进行 polyfill：
 
 ```js
 if(!Promise.allSettled) {
   Promise.allSettled = function(promises) {
-    return Promise.all(promises.map(p => Promise.resolve(p).then(v => ({
+    return Promise.all(promises.map(p => Promise.resolve(p).then(value => ({
       state: 'fulfilled',
-      value: v,
-    }), r => ({
+      value
+    }), reason => ({
       state: 'rejected',
-      reason: r,
+      reason
     }))));
   };
 }
 ```
 
-在这段代码中，`promises.map` 获取输入值，并使用 `p => Promise.resolve(p)` 将该值转换为 promise（以防传递了非 promise），然后向其添加 `.then` 处理器。
+在这段代码中，`promises.map` 获取输入值，并通过 `p => Promise.resolve(p)` 将输入值转换为 promise（以防传递了 non-promise），然后向每一个 promise 都添加 `.then` 处理器（handler）。
 
-这个处理器将成功的结果 `v` 转换为 `{state:'fulfilled', value:v}`，将错误的结果 `r` 转换为 `{state:'rejected', reason:r}`。这正是 `Promise.allSettled` 的格式。
+这个处理器（handler）将成功的结果 `v` 转换为 `{state:'fulfilled', value:v}`，将 error `r` 转换为 `{state:'rejected', reason:r}`。这正是 `Promise.allSettled` 的格式。
 
-然后我们就可以使用 `Promise.allSettled` 来获取结果或*所有*给出的 promise，即使其中一些被 reject。
+然后我们就可以使用 `Promise.allSettled` 来获取 **所有** 给定的 promise 的结果，即使其中一些被 reject。
 
 ## Promise.race
 
-与 `Promise.all` 类似，它接受一个可迭代的 promise 集合，但是它只等待第一个完成（或者 error）而不会等待所有都完成，然后继续执行。
+与 `Promise.all` 类似，但只等待第一个 settled 的 promise 并获取其结果（或 error）。
 
 语法：
 
@@ -205,7 +205,7 @@ if(!Promise.allSettled) {
 let promise = Promise.race(iterable);
 ```
 
-例如，这里的结果会是 `1`：
+例如，这里的结果将是 `1`：
 
 ```js run
 Promise.race([
@@ -215,21 +215,23 @@ Promise.race([
 ]).then(alert); // 1
 ```
 
-因此，第一个结果/错误会成为整个 `Promise.race` 的结果。在第一个 promise 被解决（“赢得比赛[wins the race]”）后，所有后面的结果/错误都会被忽略。
+这里第一个 promise 最快，所以它变成了结果。第一个 settled 的 promise “赢得了比赛”之后，所有进一步的 result/error 都会被忽略。
 
 
 ## Promise.resolve/reject
 
-Methods `Promise.resolve` and `Promise.reject` are rarely needed in modern code, because `async/await` syntax (we'll cover it [a bit later](info:async-await)) makes them somewhat obsolete.
+在现代的代码中，很少会需要使用 `Promise.resolve` 和 `Promise.reject` 方法，因为 `async/await` 语法（我们会在 [稍后](info:async-await) 讲到）使它们变得有些过时了。
 
-We cover them here for completeness and for those who can't use `async/await` for some reason.
+完整起见，以及考虑到那些出于某些原因而无法使用 `async/await` 的人，我们在这里对它们进行介绍。
 
 ### Promise.resolve
 
-语法：
+`Promise.resolve(value)` 用结果 `value` 创建一个 resolved 的 promise。
+
+如同：
 
 ```js
-let promise = Promise.resolve(value);
+let promise = new Promise(resolve => resolve(value));
 ```
 
 根据给定的 `value` 值返回 resolved promise。

--- a/1-js/11-async/05-promise-api/article.md
+++ b/1-js/11-async/05-promise-api/article.md
@@ -275,12 +275,12 @@ let promise = new Promise((resolve, reject) => reject(error));
 
 `Promise` 类有 5 种静态方法：
 
-1. `Promise.all(promises)` - 等待所有 promise 都 resolve 时返回存放它们结果的数组。如果给定的任意一个 promise 为 reject，那么它就会变成 `Promise.all` 的错误结果，所有的其他结果都会被忽略。
-2. `Promise.allSettled(promises)` （新方法） - 等待所有 promise resolve 或者 reject，并以对象形式返回它们结果数组：
-    - `state`：`‘fulfilled’` 或 `‘rejected’`
-    - `value`（如果 fulfilled）或 `reason`（如果 rejected）
-3. `Promise.race(promises)` - 等待第一个 promise 被解决，其结果/错误即为结果。
-4. `Promise.resolve(value)` - 根据给定值返回 resolved promise。
-5. `Promise.reject(error)` - 根据给定错误返回 rejected promise。
+1. `Promise.all(promises)` - 等待所有 promise 都 resolve 时，返回存放它们结果的数组。如果给定的任意一个 promise 为 reject，那么它就会变成 `Promise.all` 的 error，所有其他 promise 的结果都会被忽略。
+2. `Promise.allSettled(promises)`（ES2020 新增方法）- 等待所有 promise 都 settle 时，并以包含以下内容的对象数组的形式返回它们的结果：
+    - `state`: `"fulfilled"` 或 `"rejected"`
+    - `value`（如果 fulfilled）或 `reason`（如果 rejected）。
+3. `Promise.race(promises)` - 等待第一个 settle 的 promise，并将其 result/error 作为结果。
+4. `Promise.resolve(value)` - 使用给定 value 创建一个 resolved 的 promise。
+5. `Promise.reject(error)` - 使用给定 error 创建一个 rejected 的 promise。
 
 这五个方法中，`Promise.all` 可能是在实战中使用最多的。

--- a/1-js/11-async/05-promise-api/article.md
+++ b/1-js/11-async/05-promise-api/article.md
@@ -257,36 +257,30 @@ function loadCached(url) {
 }
 ```
 
-我们可以使用 `loadCached(url).then(…)`，因为该函数必定返回一个 promise。这是 `Promise.resolve` 在 `(*)` 行的目的：它确保了接口的统一性。我们可以在 `loadCached` 之后使用 `.then`。
+我们可以使用 `loadCached(url).then(…)`，因为该函数保证了会返回一个 promise。我们就可以放心地在 `loadCached` 后面使用 `.then`。这就是 `(*)` 行中 `Promise.resolve` 的目的。
 
 ### Promise.reject
 
-语法：
+`Promise.reject(error)` 用 `error` 创建一个 rejected 的 promise。
 
-```js
-let promise = Promise.reject(error);
-```
-
-创建一个带有 `error` 的 rejected promise。
-
-就像这样：
+如同：
 
 ```js
 let promise = new Promise((resolve, reject) => reject(error));
 ```
 
-我们会在此讨论它的完整性，但在实际工作中，我们很少这样使用。
+实际上，这个方法几乎从未被使用过。
 
 ## 总结
 
 `Promise` 类有 5 种静态方法：
 
-1. `Promise.resolve(value)` - 根据给定值返回 resolved promise。
-2. `Promise.reject(error)` - 根据给定错误返回 rejected promise。
-3. `Promise.all(promises)` - 等待所有的 promise 为 resolve 时返回存放它们结果的数组。如果任意给定的 promise 为 reject，那么它就会变成 `Promise.all` 的错误结果，所有的其他结果都会被忽略。
-4. `Promise.allSettled(promises)` （新方法） - 等待所有 promise resolve 或者 reject，并以对象形式返回它们结果数组：
+1. `Promise.all(promises)` - 等待所有 promise 都 resolve 时返回存放它们结果的数组。如果给定的任意一个 promise 为 reject，那么它就会变成 `Promise.all` 的错误结果，所有的其他结果都会被忽略。
+2. `Promise.allSettled(promises)` （新方法） - 等待所有 promise resolve 或者 reject，并以对象形式返回它们结果数组：
     - `state`：`‘fulfilled’` 或 `‘rejected’`
     - `value`（如果 fulfilled）或 `reason`（如果 rejected）
-5. `Promise.race(promises)` - 等待第一个 promise 被解决，其结果/错误即为结果。
+3. `Promise.race(promises)` - 等待第一个 promise 被解决，其结果/错误即为结果。
+4. `Promise.resolve(value)` - 根据给定值返回 resolved promise。
+5. `Promise.reject(error)` - 根据给定错误返回 rejected promise。
 
-这五个方法中，`Promise.all` 在实战中使用的最多。
+这五个方法中，`Promise.all` 可能是在实战中使用最多的。

--- a/1-js/11-async/05-promise-api/article.md
+++ b/1-js/11-async/05-promise-api/article.md
@@ -99,8 +99,8 @@ Promise.all([
 `Promise.all` 没有采取任何措施来取消它们，因为 promise 中没有“取消”的概念。在 [另一个章节](info:fetch-abort) 中，我们将介绍可以帮助我们解决这个问题（译注：指的是“取消” promise）的 `AbortController`，但它不是 Promise API 的一部分。
 ```
 
-````smart header="`Promise.all(iterable)` 允许“迭代”中的非 promise（non-promise）的 \“常规\” 值"
-通常，`Promise.all(...)` 接受可迭代的 promise 集合（大部分情况下是数组）。但是如果这些对象中的任意一个不是 promise，它将会被直接包装进 `Promise.resolve`。
+````smart header="`Promise.all(iterable)` 允许在 `iterable` 中使用 non-promise 的“常规”值"
+通常，`Promise.all(...)` 接受可迭代对象（iterable）的 promise（大多数情况下是数组）。但是，如果这些对象中的任意一个都不是 promise，那么它将被“按原样”传递给结果数组。
 
 例如，这里的结果是 `[1, 2, 3]`：
 
@@ -109,12 +109,12 @@ Promise.all([
   new Promise((resolve, reject) => {
     setTimeout(() => resolve(1), 1000)
   }),
-  2, // 视为 Promise.resolve(2)
-  3  // 视为 Promise.resolve(3)
+  2,
+  3
 ]).then(alert); // 1, 2, 3
 ```
 
-所以我们可以很方便的将准备好的值传递给 `Promise.all`。
+所以我们可以在方便的地方将准备好的值传递给 `Promise.all`。
 ````
 
 ## Promise.allSettled


### PR DESCRIPTION
**目标章节**：1-js/11-async/05-promise-api

**当前上游最新 commit**：https://github.com/javascript-tutorial/en.javascript.info/commit/36737518f826dbb3036db5eebcbe716184ff25a2

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | https://github.com/javascript-tutorial/en.javascript.info/commit/a53fb38c493771c1d2ccc4e2ef68690a072064fd | 更新译文
