### PR TITLE
Update translation of 1-js/11-async/06-promisify and 07-microtask-queue

### DIFF
--- a/1-js/11-async/06-promisify/article.md
+++ b/1-js/11-async/06-promisify/article.md
@@ -96,7 +96,7 @@ function promisify(f, manyArgs = false) {
   };
 };
 
-// 用法
+// 用法：
 f = promisify(f, true);
 f(...).then(arrayOfResults => ..., err => ...)
 ```

--- a/1-js/11-async/06-promisify/article.md
+++ b/1-js/11-async/06-promisify/article.md
@@ -1,12 +1,10 @@
 # Promisification
 
-Promisification —— 一个长单词，用来描述一个简单的转换。它指将一个接受回调的函数转换为一个返回 promise 的函数。
+"Promisification" 是用于一个简单转换的一个长单词。它指将一个接受回调的函数转换为一个返回 promise 的函数。
 
-准确一点说就是，我们创建了一个包装函数（wrapper-function）来做同样的事情，在内部调用原来的函数，但返回一个 promise。
+由于许多函数和库都是基于回调的，因此，在实际开发中经常会需要进行这种转换。因为使用 promise 更加方便，所以将基于回调的函数和库 promisify 是有意义的。（译注：promisify 即指 promise 化）
 
-在实际开发中经常需要这种转换，因为很多函数和库都是基于回调（callback-based）的。但是，使用 promise 更加方便。因此，将它们（函数和库）promisify 是很有意义的。
-
-例如，章节 <info:callbacks> 里面写的 `loadScript(src, callback)`。
+例如，在 <info:callbacks> 一章中我们有 `loadScript(src, callback)`。
 
 ```js run
 function loadScript(src, callback) {
@@ -23,7 +21,7 @@ function loadScript(src, callback) {
 // loadScript('path/script.js', (err, script) => {...})
 ```
 
-来对它进行 promisify 吧。新的函数 `loadScriptPromise(src)` 将会做同样的事情，但只接受 `src`（没有回调）并返回 promise。
+让我们将其 promisify 吧。新的 `loadScriptPromise(src)` 将会达到同样的结果，但它只接受 `src`（没有回调）并返回 promise。
 
 ```js
 let loadScriptPromise = function(src) {
@@ -39,31 +37,29 @@ let loadScriptPromise = function(src) {
 // loadScriptPromise('path/script.js').then(...)
 ```
 
-现在， `loadScriptPromise` 非常适用于我们基于 promise（promise-based）的代码。
+现在，`loadScriptPromise` 非常适合基于 promise 的代码。
 
-如我们所见，它将所有工作委派给原来的 `loadScript`，提供了自己的回调。此回调转换成了 promise 的 `resolve/reject`。
+正如我们所看到的，它将所有工作都委托给原始的 `loadScript`，并提供了转换成 promise `resolve/reject` 的自己的回调。
 
-由于我们可能需要 promisify 很多函数，使用一个助手（helper）很有意义。
+在实际开发中，我们可能需要 promisify 很多函数，所以使用一个 helper 很有意义。我们将其称为 `promisify(f)`：它接受一个需要被 promisify 的函数 `f`，并返回一个包装（wrapper）函数。
 
-实际上很简单 —— 下面的 `promisify(f)` 接受一个要被 promisify 的函数，并返回一个包装函数。
-
-这个包装函数做了跟上面代码一样的事情：返回 promise 并且把调用传递给原来的 `f`，在自定义的回调函数中跟踪结果：
+该包装（wrapper）函数的功能和上面的代码相同：返回一个 promise，将调用传递给原始的函数 `f`，并在自定义的回调中跟踪结果：
 
 ```js
 function promisify(f) {
-  return function (...args) { // 返回一个包装函数
+  return function (...args) { // 返回一个包装函数（wrapper-function）
     return new Promise((resolve, reject) => {
-      function callback(err, result) { // 给 f 用的自定义回调
+      function callback(err, result) { // 我们对 f 的自定义的回调
         if (err) {
-          return reject(err);
+          reject(err);
         } else {
           resolve(result);
         }
       }
 
-      args.push(callback); // 在参数的最后附上我们自定义的回调函数
+      args.push(callback); // 将我们的自定义的回调附加到 f 参数（arguments）的末尾
 
-      f.call(this, ...args); // 调用原来的函数
+      f.call(this, ...args); // 调用原始的函数
     });
   };
 };
@@ -73,22 +69,22 @@ let loadScriptPromise = promisify(loadScript);
 loadScriptPromise(...).then(...);
 ```
 
-这里我们假设，原来的函数接受一个有两个参数 `(err, result)` 的回调。那是我们最经常遇到的（形式）。那么我们的自定义回调的格式确实正确，而且 `promisify` 在此案例中非常适用。
+这里我们假设，原始的函数期望一个带有两个参数 `(err, result)` 的回调。这就是我们最常遇到的形式。那么我们的自定义回调的格式完全正确，并且 `promisify` 在这种情况下非常有用。
 
-但是如果原来的 `f` 接受一个带更多参数的回调 `callback(err, res1, res2)`，该怎么办？
+但是如果原始的 `f` 期望一个带有更多参数的回调 `callback(err, res1, res2, ...)`，该怎么办呢？
 
-下面是 `promisify` 的修改版，它返回一个装有多个回调结果的数组：
+下面是 `promisify` 的更高级的版本：如果像这样进行调用 `promisify(f, true)`，那么 promise 的结果将是回调结果的数组 `[res1, res2, ...]`：
 
 ```js
-// 设定为 promisify(f, true) 来获取结果数组
+// promisify(f, true) 来获取结果数组
 function promisify(f, manyArgs = false) {
   return function (...args) {
     return new Promise((resolve, reject) => {
-      function *!*callback(err, ...results*/!*) { // 给 f 用的自定义回调
+      function *!*callback(err, ...results*/!*) { // 我们自定义的 f 的回调
         if (err) {
-          return reject(err);
+          reject(err);
         } else {
-          // 如果 manyArgs 被指定值，则 resolve 所有回调结果
+          // 如果 manyArgs 被指定，则使用所有回调的结果 resolve
           *!*resolve(manyArgs ? results : results[0]);*/!*
         }
       }
@@ -100,19 +96,19 @@ function promisify(f, manyArgs = false) {
   };
 };
 
-// 用法：
+// 用法
 f = promisify(f, true);
 f(...).then(arrayOfResults => ..., err => ...)
 ```
 
-在一些案例中，`err` 可能没有（在参数里）：`callback(result)`，或者回调的格式有些奇怪，那么我们可以在不使用助手（helper）的情况下去手动实现 promisify。
+对于一些更奇特的回调格式，例如根本没有 `err` 的格式：`callback(result)`，我们可以手动 promisify 这样的函数，而不使用 helper。
 
-也有一些提供更灵活一点的 promisification 函数的模块，例如 [es6-promisify](https://github.com/digitaldesignlabs/es6-promisify)。在 Node.js 中，有一个内置的 promisify 函数 `util.promisify`。
+也有一些具有更灵活一点的 promisification 函数的模块（module），例如 [es6-promisify](https://github.com/digitaldesignlabs/es6-promisify)。在 Node.js 中，有一个内建的 promisify 函数 `util.promisify`。
 
 ```smart
-Promisification 是一种很好的方法，特别是你使用 `async/await` 的时候（请看下一节），但不是回调函数的完全替代品。
+Promisification 是一种很好的方法，特别是在你使用 `async/await` 的时候（请看下一章），但不是回调的完全替代。
 
-请记住，一个 promise 可能只有一个结果，但是技术上，一个回调函数可能被多次调用。
+请记住，一个 promise 可能只有一个结果，但从技术上讲，一个回调可能被调用很多次。
 
-因此 promisification 仅仅对调用一次回调的函数有用。以后的调用将会被忽略。
+因此，promisification 仅适用于调用一次回调的函数。进一步的调用将被忽略。
 ```

--- a/1-js/11-async/07-microtask-queue/article.md
+++ b/1-js/11-async/07-microtask-queue/article.md
@@ -3,46 +3,46 @@
 
 Promise 的处理程序（handlers）`.then`、`.catch` 和 `.finally` 都是异步的。
 
-即便一个 promise 立即被 resolve，`.then`、`.catch` 和 `.finally` *下面*的代码也会在这些处理程序之前被执行。
+即便一个 promise 立即被 resolve，`.then`、`.catch` 和 `.finally` **下面** 的代码也会在这些处理程序（handler）之前被执行。
 
 示例代码如下：
 
 ```js run
 let promise = Promise.resolve();
 
-promise.then(() => alert("promise done"));
+promise.then(() => alert("promise done!"));
 
-alert("code finished"); // 该警告框会首先弹出
+alert("code finished"); // 这个 alert 先显示
 ```
 
 如果你运行它，你会首先看到 `code finished`，然后才是 `promise done`。
 
-这很奇怪，因为这个 promise 绝对在开头就被执行了。
+这很奇怪，因为这个 promise 肯定是一开始就完成的。
 
-为什么 `.then` 会在之后被触发？这是怎么回事？
+为什么 `.then` 会在之后才被触发？这是怎么回事？
 
 ## 微任务队列（Microtasks queue）
 
-异步任务需要适当的管理。为此，JavaScript 标准规定了一个内部队列 `PromiseJobs`，通常被称为 “微任务队列”（v8 术语）。
+异步任务需要适当的管理。为此，ECMA 标准规定了一个内部队列 `PromiseJobs`，通常被称为“微任务队列（microtask queue）”（ES8 术语）。
 
-如[规范](https://tc39.github.io/ecma262/#sec-jobs-and-job-queues)中所述：
+如 [规范](https://tc39.github.io/ecma262/#sec-jobs-and-job-queues) 中所述：
 
-- 队列是先进先出的：首先进入队列的任务会首先运行。
-- 只有在引擎中没有其它任务运行时，才会启动任务队列的执行。
+- 队列（queue）是先进先出的：首先进入队列的任务会首先运行。
+- 只有在 JavaScript 引擎中没有其它任务在运行时，才开始执行任务队列中的任务。
 
-或者，简单地说，当一个 promise 准备就绪时，它的 `.then/catch/finally` 处理程序就被放入队列中。但是不会立即被执行。当 JavaScript 引擎执行完当前的代码，它会从队列中获取任务并执行它。
+或者，简单地说，当一个 promise 准备就绪时，它的 `.then/catch/finally` 处理程序（handler）就会被放入队列中：但是它们不会立即被执行。当 JavaScript 引擎执行完当前的代码，它会从队列中获取任务并执行它。
 
-这就是示例中的“code finished”会首先出现的原因。
+这就是为什么在上面那个示例中 "code finished" 会先显示。
 
 ![](promiseQueue.svg)
 
-Promise 处理程序总是被放入这个内部队列中。
+Promise 的处理程序（handler）总是会经过这个内部队列。
 
-如果有一个 promise 链带有多个 `.then/catch/finally`，那么它们中每一个都是异步执行的。也就是说，它会首先排入一个队列，只有当前代码执行完毕而且先前的排好队的处理程序都完成时才会被执行。
+如果有一个包含多个 `.then/catch/finally` 的链，那么它们中的每一个都是异步执行的。也就是说，它会首先进入队列，然后在当前代码执行完成并且先前排队的处理程序（handler）都完成时才会被执行。
 
-**如果返回值的顺序对我们很重要该怎么办？我们怎么才能让 `code finished` 在 `promise done` 之后出现呢？**
+**如果执行顺序对我们很重要该怎么办？我们怎么才能让 `code finished` 在 `promise done` 之后运行呢？**
 
-很简单，只需要像下面这样把返回 `code finished` 的 `.then` 处理程序放入队列中：
+很简单，只需要像下面这样使用 `.then` 将其放入队列：
 
 ```js run
 Promise.resolve()
@@ -54,13 +54,13 @@ Promise.resolve()
 
 ## 未处理的 rejection
 
-还记得 <info:promise-error-handling> 一章中“未处理的 rejection”事件吗？
+还记得 <info:promise-error-handling> 一章中的 `unhandledrejection` 事件吗？
 
-现在我们可以解释 JavaScript 是如何发现 rejection 是未被处理的。
+现在，我们可以确切地看到 JavaScript 是如何发现未处理的 rejection 的。
 
-**“未处理的 rejection”是指在 microtask 队列结束时未处理的 promise 错误。**
+**如果一个 promise 的 error 未被在微任务队列的末尾进行处理，则会出现“未处理的 rejection”。**
 
-正常来说，如果我们预期可能会发生错误，我们会添加 `.catch` 到 promise 链上去处理它：
+正常来说，如果我们预期可能会发生错误，我们会在 promise 链上添加 `.catch` 来处理 error：
 
 ```js run
 let promise = Promise.reject(new Error("Promise Failed!"));
@@ -68,11 +68,11 @@ let promise = Promise.reject(new Error("Promise Failed!"));
 promise.catch(err => alert('caught'));
 */!*
 
-// 不会运行：错误已被处理
+// 不会运行：error 已经被处理
 window.addEventListener('unhandledrejection', event => alert(event.reason));
 ```
 
-……但是如果我们忘记添加 `.catch`，那么微任务队列清空后，JavaScript 引擎会触发以下事件：
+但是如果我们忘记添加 `.catch`，那么，微任务队列清空后，JavaScript 引擎会触发下面这事件：
 
 ```js run
 let promise = Promise.reject(new Error("Promise Failed!"));
@@ -81,32 +81,32 @@ let promise = Promise.reject(new Error("Promise Failed!"));
 window.addEventListener('unhandledrejection', event => alert(event.reason));
 ```
 
-如果我们迟点再处理这个错误会怎样？比如：
+如果我们迟一点再处理这个 error 会怎样？例如：
 
 ```js run
 let promise = Promise.reject(new Error("Promise Failed!"));
 *!*
-setTimeout(() => promise.catch(err => alert('caught')));
+setTimeout(() => promise.catch(err => alert('caught')), 1000);
 */!*
 
 // Error: Promise Failed!
 window.addEventListener('unhandledrejection', event => alert(event.reason));
 ```
 
-现在，如果你运行以上的代码，我们先会看到 `Promise Failed!` 的消息，然后才是 `caught`。
+现在，如果我们运行上面这段代码，我们会先看到 `Promise Failed!`，然后才是 `caught`。
 
-如果我们并不了解微任务队列，我们可能想知道：“为什么 `unhandledrejection` 的处理程序会运行？我们已经去捕捉（catch）这个错误了！”
+如果我们并不了解微任务队列，我们可能会想：“为什么 `unhandledrejection` 处理程序（handler）会运行？我们已经捕获（catch）并处理了 error！”
 
-但是现在我们知道 `unhandledrejection` 在 microtask 队列完成时才会被生成：引擎会检查 promise，如果其中的任何一个出现“rejected”状态，`unhandledrejection` 事件就会被触发。
+但是现在我们知道了，当微任务队列中的任务都完成时，才会生成 `unhandledrejection`：引擎会检查 promise，如果 promise 中的任意一个出现 "rejected" 状态，`unhandledrejection` 事件就会被触发。
 
-在这个例子中，被添加到 `setTimeout` 的 `.catch` 也会执行，只是会在 `unhandledrejection` 事件出现之后才执行，所以并没有改变什么（没有发挥作用）。
+在上面这个例子中，被添加到 `setTimeout` 中的 `.catch` 也会被触发。只是会在 `unhandledrejection` 事件出现之后才会被触发，所以它并没有改变什么（没有发挥作用）。
 
 ## 总结
 
-Promise 处理始终是异步的，因为所有 promise 操作都被放入内部的“promise jobs”队列执行，也被称为“微任务队列”（v8 术语）。
+Promise 处理始终是异步的，因为所有 promise 操作都会通过内部的 "promise jobs" 队列，也被称为“微任务队列”（ES8 术语）。
 
-**因此，`.then/catch/finally` 处理程序总是在当前代码完成后才被调用。**
+因此，`.then/catch/finally` 处理程序（handler）总是在当前代码完成后才会被调用。**
 
-如果我们需要确保一段代码在 `.then/catch/finally` 之后被执行，最好将它添加到 `.then` 的链式调用中。
+如果我们需要确保一段代码在 `.then/catch/finally` 之后被执行，我们可以将它添加到链式调用的 `.then` 中。
 
-在大部分 JavaScript 引擎中（包括浏览器和 Node.js），微任务的概念与“事件循环”和“宏任务”紧密联系。由于这些概念跟 promises 没有直接关系，它们被涵盖在本教程另外的章节 <info:event-loop> 中。
+在大多数 JavaScript 引擎中（包括浏览器和 Node.js），微任务（microtasks）的概念与“事件循环（event loop）”和“宏任务（macrotasks）”紧密相关。由于这些概念跟 promise 没有直接关系，所以我们在本教程另外一部分的 <info:event-loop> 一章中对它们进行了介绍。


### PR DESCRIPTION
**目标章节**：1-js/11-async/06-promisify and 07-microtask-queue

**当前上游最新 commit**：https://github.com/javascript-tutorial/en.javascript.info/commit/36737518f826dbb3036db5eebcbe716184ff25a2

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
1-js/11-async/06-promisify/article.md | https://github.com/javascript-tutorial/en.javascript.info/commit/1304aa12fcd4bd5e4c312ef43f63192382fa50bb | 更新译文
1-js/11-async/07-microtask-queue/article.md | https://github.com/javascript-tutorial/en.javascript.info/commit/837f7ab024e49cf99a9ffdab0126372d58cb1532 | 更新译文
