### PR TITLE
示例代码中的 JSON 格式错误

### DIFF
--- a/1-js/11-async/03-promise-chaining/article.md
+++ b/1-js/11-async/03-promise-chaining/article.md
@@ -248,7 +248,7 @@ fetch('/article/promise-chaining/user.json')
   })
   .then(function(text) {
     // ...这是远程文件的内容
-    alert(text); // {"name": "iliakan", isAdmin: true}
+    alert(text); // {"name": "iliakan", "isAdmin": true}
   });
 ```
 


### PR DESCRIPTION
在 #更复杂的示例：fetch 这一小节的第一个示例代码中 alert(text) 是 JSON 格式，运行代码弹出框中 "isAdmin" 带有引号，但是注释没有