### PR TITLE
Fix: confusing translation sentence

### DIFF
--- a/1-js/06-advanced-functions/06-function-object/article.md
+++ b/1-js/06-advanced-functions/06-function-object/article.md
@@ -93,7 +93,7 @@ alert(many.length); // 2
 
 可以看到，余参不参与计数。
 
-属性 `length` 有时在操作其它函数的函数中，用来做[内省/运行时检查（introspection）](https://zh.wikipedia.org/wiki/内省_(计算机科学))。
+属性 `length` 有时在操作其它函数的函数中用于做 [内省/运行时检查（introspection）](https://zh.wikipedia.org/wiki/内省_(计算机科学))。
 
 比如，下面的代码中函数 `ask` 接受一个询问答案的参数 `question` 和可能包含任意数量 `handler` 的参数 `...handlers`。
 

--- a/1-js/06-advanced-functions/06-function-object/article.md
+++ b/1-js/06-advanced-functions/06-function-object/article.md
@@ -93,7 +93,7 @@ alert(many.length); // 2
 
 可以看到，余参不参与计数。
 
-属性 `length` 有时用于对其他函数进行操作的函数的 [自我检查（introspection）](https://en.wikipedia.org/wiki/Type_introspection)。在函数中操作其它函数的内省。
+属性 `length` 有时在操作其它函数的函数中，用来做[内省/运行时检查（introspection）](https://zh.wikipedia.org/wiki/内省_(计算机科学))。
 
 比如，下面的代码中函数 `ask` 接受一个询问答案的参数 `question` 和可能包含任意数量 `handler` 的参数 `...handlers`。
 


### PR DESCRIPTION
Original in English: 
> The length property is sometimes used for introspection in functions that operate on other functions.

个人认为**运行时检查**比**内省**更容易让读者理解。另外链接改到了中文的维基百科。

---

**目标章节**：1-js/06-advanced-functions/06-function-object

**当前上游最新 commit**：无
**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | 无 | 修改语句不通

> 注意，参考上游 commit 是指你所修改的文件，在英文仓库中同名文件的对应 commit，即你此次提交的修改的依据。如果本 PR 你只是提交一个文字或者语句优化，并非根据上游英文仓库的修改而提交的更新，则请填无。
