### PR TITLE
FIX: minor typo error in 8-web-components/7-shadow-dom-events/article.md

### DIFF
--- a/8-web-components/7-shadow-dom-events/article.md
+++ b/8-web-components/7-shadow-dom-events/article.md
@@ -187,6 +187,6 @@ inner.dispatchEvent(new CustomEvent('test', {
 
 这些事件仅能在同一 DOM 中的元素上捕获。
 
-如果我们发送一个 `CustomEvent`，那么我们应该显示设置 `composed: true`。
+如果我们发送一个 `CustomEvent`，那么我们应该明确地设置 `composed: true`。
 
 请注意，如果是嵌套组件，一个 shadow DOM 可能嵌套到另外一个 shadow DOM 中。在这种情况下合成事件冒泡到所有 shadow DOM 边界。因此，如果一个事件仅用于直接封闭组件，我们也可以在 shadow host 上发送它并设置 `composed: false`。这样它就不在组件 shadow DOM 中，也不会冒泡到更高级别的 DOM。

--- a/8-web-components/7-shadow-dom-events/article.md
+++ b/8-web-components/7-shadow-dom-events/article.md
@@ -187,6 +187,6 @@ inner.dispatchEvent(new CustomEvent('test', {
 
 这些事件仅能在同一 DOM 中的元素上捕获。
 
-如果我们发送一个 `CustomEvent`，那么我们应该明确地设置 `composed: true`。
+如果我们发送一个 `CustomEvent`，那么我们应该显式地设置 `composed: true`。
 
 请注意，如果是嵌套组件，一个 shadow DOM 可能嵌套到另外一个 shadow DOM 中。在这种情况下合成事件冒泡到所有 shadow DOM 边界。因此，如果一个事件仅用于直接封闭组件，我们也可以在 shadow host 上发送它并设置 `composed: false`。这样它就不在组件 shadow DOM 中，也不会冒泡到更高级别的 DOM。


### PR DESCRIPTION
修正翻译错误，“显示设置”修正为“明确地设置”

**目标章节**：例如 8-web-components/7-shadow-dom-events/article.md

**当前上游最新 commit**：https://github.com/javascript-tutorial/zh.javascript.info/commit/a420010ddc553cc595c095665ef40952cd0d8a08

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | 无 | 修改翻译错误

> 注意，参考上游 commit 是指你所修改的文件，在英文仓库中同名文件的对应 commit，即你此次提交的修改的依据。如果本 PR 你只是提交一个文字或者语句优化，并非根据上游英文仓库的修改而提交的更新，则请填无。
