### PR TITLE
fix: 修改加粗显示的段落不完整的问题

### DIFF
--- a/1-js/02-first-steps/03-strict-mode/article.md
+++ b/1-js/02-first-steps/03-strict-mode/article.md
@@ -80,7 +80,7 @@ alert("some code");
 
 现代 JavaScript 支持 "classes" 和 "modules" —— 高级语言结构（本教程后续章节会讲到），它们会自动启用 `use strict`。因此，如果我们使用它们，则无需添加 `"use strict"` 指令。
 
-**因此，目前我们欢迎将 `"use strict";` 写在脚本的顶部。稍后，当你的代码全都写在了 class 和 module 中时，你则可以将 `"use strict";` 这行代码省略掉。
+**因此，目前我们欢迎将 `"use strict";` 写在脚本的顶部。稍后，当你的代码全都写在了 class 和 module 中时，你则可以将 `"use strict";` 这行代码省略掉。**
 
 目前，我们已经基本了解了 `use strict`。
 


### PR DESCRIPTION
原文段落链接：https://github.com/javascript-tutorial/en.javascript.info/blob/master/1-js/02-first-steps/03-strict-mode/article.md#should-we-use-strict

**目标章节**：1-js/02-first-steps/03-strict-mode

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | https://github.com/javascript-tutorial/en.javascript.info/blame/master/1-js/02-first-steps/03-strict-mode/article.md#L83| Markdown 格式修正
