### PR TITLE
UPD: update 1-js/11-async/08-async-await/article.md to 2021-03-19

### DIFF
--- a/1-js/11-async/08-async-await/article.md
+++ b/1-js/11-async/08-async-await/article.md
@@ -139,6 +139,8 @@ let user = await response.json();
   ...
 })();
 ```
+
+P.S. 新特性：从 v8 引擎 8.9 版本开始，顶层 await 可以在 [模块](info:modules) 中工作。
 ````
 
 ````smart header="`await` 接受 \"thenables\""
@@ -184,7 +186,7 @@ class Waiter {
 
 new Waiter()
   .wait()
-  .then(alert); // 1
+  .then(alert); // 1 （ alert 等同于 result => alert(result) ）
 ```
 这里的含义是一样的：它确保了方法的返回值是一个 promise 并且可以在方法中使用 `await`。
 

--- a/1-js/11-async/08-async-await/article.md
+++ b/1-js/11-async/08-async-await/article.md
@@ -140,7 +140,7 @@ let user = await response.json();
 })();
 ```
 
-P.S. 新特性：从 v8 引擎 8.9 版本开始，顶层 await 可以在 [模块](info:modules) 中工作。
+P.S. 新特性：从 V8 引擎 8.9+ 版本开始，顶层 await 可以在 [模块](info:modules) 中工作。
 ````
 
 ````smart header="`await` 接受 \"thenables\""
@@ -186,7 +186,7 @@ class Waiter {
 
 new Waiter()
   .wait()
-  .then(alert); // 1 （ alert 等同于 result => alert(result) ）
+  .then(alert); // 1（alert 等同于 result => alert(result)）
 ```
 这里的含义是一样的：它确保了方法的返回值是一个 promise 并且可以在方法中使用 `await`。
 


### PR DESCRIPTION
**目标章节**：1-js/11-async/08-async-await

**当前上游最新 commit**：[065e31d](https://github.com/javascript-tutorial/en.javascript.info/commit/065e31d0d40bc81a87ff09450388f803a197a8f0#diff-03b9fb20d098766bb5b39b9dc0d6106c78ddca4b411e31b09eea6d021696c27c)

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | [065e31d](https://github.com/javascript-tutorial/en.javascript.info/commit/065e31d0d40bc81a87ff09450388f803a197a8f0#diff-03b9fb20d098766bb5b39b9dc0d6106c78ddca4b411e31b09eea6d021696c27c) | 参考上游增加部分说明
