### PR TITLE
Update article.md

### DIFF
--- a/1-js/11-async/08-async-await/article.md
+++ b/1-js/11-async/08-async-await/article.md
@@ -140,7 +140,9 @@ let user = await response.json();
 })();
 ```
 
-P.S. 新特性：从 V8 引擎 8.9+ 版本开始，顶层 await 可以在 [模块](info:modules) 中工作。
+P.S. 新特性：
+从 V8 引擎 8.9+ 版本开始，顶层 await 可以在 [模块](info:modules) 中工作。
+从 V8 引擎 9.1+ 版本开始，顶层 await 可以在 Top-level 中工作。
 ````
 
 ````smart header="`await` 接受 \"thenables\""


### PR DESCRIPTION
update V8 support for await

**目标章节**：1-js/11-async/08-async-await/

**本 PR 所做更改如下：**

添加 V8 对 await 最新支持的更新，
详见 [New in Chrome 91](https://developer.chrome.com/blog/new-in-chrome-91/)
