### PR TITLE
IMP: remove unnecessay character

### DIFF
--- a/5-network/07-url/article.md
+++ b/5-network/07-url/article.md
@@ -199,7 +199,7 @@ alert(url); // https://google.com/search?q=Rock&Roll
 因此，对于每个搜索参数，我们应该使用 `encodeURIComponent`，以将其正确地插入到 URL 字符串中。最安全的方式是对 name 和 value 都进行编码，除非我们能够绝对确保它只包含允许的字符。
 
 ````smart header="`encode*` 与 `URL` 之间的编码差异"
-类 [URL](https://url.spec.whatwg.org/#url-class) 和 [URLSearchParams](https://url.spec.whatwg.org/#interface-urlsearchparams) 基于最新的 URL 规范：[RFC3986](https://tools.ietf.org/html/rfc3986)，而 `encode*` 函数是基于过时的 [RFC2396](https://www.ietf.org/rfc/rfc2396.txt)。
+[URL](https://url.spec.whatwg.org/#url-class) 和 [URLSearchParams](https://url.spec.whatwg.org/#interface-urlsearchparams) 基于最新的 URL 规范：[RFC3986](https://tools.ietf.org/html/rfc3986)，而 `encode*` 函数是基于过时的 [RFC2396](https://www.ietf.org/rfc/rfc2396.txt)。
 
 它们之间有一些区别，例如对 IPv6 地址的编码方式不同：
 


### PR DESCRIPTION
There's no need to emphasize that URL is a class. And, this saying is just weird.
没有必要强调 URL 是类。而且这种说法比较奇怪。比如我们一般不会说`人王二强`

**目标章节**：例如 1-js/01-getting-started/1-intro

**当前上游最新 commit**：此处填写本项目英文版 https://github.com/javascript-tutorial/en.javascript.info 的最新 commit，例如 https://github.com/javascript-tutorial/zh.javascript.info/commit/b03ca00a992a73aaf213970e71f74ac1c04def33

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | a23882d | 修改部分错误

> 注意，参考上游 commit 是指你所修改的文件，在英文仓库中同名文件的对应 commit，即你此次提交的修改的依据。如果本 PR 你只是提交一个文字或者语句优化，并非根据上游英文仓库的修改而提交的更新，则请填无。
