### PR TITLE
feat: improve translation of "iterable" in 1-js/11-async/05-promise-api/article.md

### DIFF
--- a/1-js/11-async/05-promise-api/article.md
+++ b/1-js/11-async/05-promise-api/article.md
@@ -16,7 +16,7 @@
 let promise = Promise.all([...promises...]);
 ```
 
-`Promise.all` 接受一个 promise 数组作为参数（从技术上讲，它可以是任何可迭代的，但通常是一个数组）并返回一个新的 promise。
+`Promise.all` 接受一个 promise 数组作为参数（从技术上讲，它可以是任何可迭代对象，但通常是一个数组）并返回一个新的 promise。
 
 当所有给定的 promise 都被 settled 时，新的 promise 才会 resolve，并且其结果数组将成为新的 promise 的结果。
 


### PR DESCRIPTION
**目标章节**： 1-js/11-async/05-promise-api

**当前上游最新 commit**：此处填写本项目英文版 https://github.com/javascript-tutorial/en.javascript.info 的最新 commit，例如 https://github.com/javascript-tutorial/zh.javascript.info/commit/b03ca00a992a73aaf213970e71f74ac1c04def33

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | 无 | 修改部分错误

> 注意，参考上游 commit 是指你所修改的文件，在英文仓库中同名文件的对应 commit，即你此次提交的修改的依据。如果本 PR 你只是提交一个文字或者语句优化，并非根据上游英文仓库的修改而提交的更新，则请填无。

iterable 是名词，意为「可迭代的对象」。

英文释义：

> iterable: An iterable object such as an Array.
>
> ——[Promise.all() - JavaScript | MDN](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Promise/all)