### PR TITLE
fix: 修改 promisify 一章中不通顺的地方

### DIFF
--- a/1-js/11-async/06-promisify/article.md
+++ b/1-js/11-async/06-promisify/article.md
@@ -1,6 +1,6 @@
 # Promisification
 
-"Promisification" 是用于一个简单转换的一个长单词。它指将一个接受回调的函数转换为一个返回 promise 的函数。
+对于一个简单的转换来说"Promisification" 是一个长单词。它指将一个接受回调的函数转换为一个返回 promise 的函数。
 
 由于许多函数和库都是基于回调的，因此，在实际开发中经常会需要进行这种转换。因为使用 promise 更加方便，所以将基于回调的函数和库 promisify 是有意义的。（译注：promisify 即指 promise 化）
 

--- a/1-js/11-async/06-promisify/article.md
+++ b/1-js/11-async/06-promisify/article.md
@@ -1,6 +1,6 @@
 # Promisification
 
-对于一个简单的转换来说"Promisification" 是一个长单词。它指将一个接受回调的函数转换为一个返回 promise 的函数。
+对于一个简单的转换来说 “Promisification” 是一个长单词。它指将一个接受回调的函数转换为一个返回 promise 的函数。
 
 由于许多函数和库都是基于回调的，因此，在实际开发中经常会需要进行这种转换。因为使用 promise 更加方便，所以将基于回调的函数和库 promisify 是有意义的。（译注：promisify 即指 promise 化）
 


### PR DESCRIPTION
**目标章节**： 1-js/11-async/06-promisify

**当前上游最新 commit**：https://github.com/javascript-tutorial/en.javascript.info/commit/29216730a877be28d0a75a459676db6e7f5c4834

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | 无 | 修改一个翻译不通顺的地方
