### PR TITLE
Update 1-js/06-advanced-functions/02-rest-parameters-spread/article.md

### DIFF
--- a/1-js/06-advanced-functions/02-rest-parameters-spread/article.md
+++ b/1-js/06-advanced-functions/02-rest-parameters-spread/article.md
@@ -104,7 +104,7 @@ showName("Ilya");
 
 因此，当我们需要这些功能时，最好使用 rest 参数。
 
-````smart header="箭头函数是没有 `\"arguments\"`"
+````smart header="箭头函数没有 `\"arguments\"`"
 如果我们在箭头函数中访问 `arguments`，访问到的 `arguments` 并不属于箭头函数，而是属于箭头函数外部的“普通”函数。
 
 举个例子：


### PR DESCRIPTION
**目标章节**：1-js/06-advanced-functions/02-rest-parameters-spread


**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | a23882d | 修改部分错误


> Arrow functions do not have "arguments"

感觉直接翻译成「箭头函数没有`arguments`」就好了呀，「是没有」这个用法总觉得是机翻/笔误？😂