### PR TITLE
fix: fix missing translation

### DIFF
--- a/9-regular-expressions/10-regexp-greedy-and-lazy/4-find-html-tags-greedy-lazy/task.md
+++ b/9-regular-expressions/10-regexp-greedy-and-lazy/4-find-html-tags-greedy-lazy/task.md
@@ -12,4 +12,4 @@ let str = '<> <a href="/"> <input type="radio" checked> <b>';
 alert( str.match(reg) ); // '<a href="/">', '<input type="radio" checked>', '<b>'
 ```
 
-这里我们假设标签属性中不会包含 `<` 和 `>`（也包括引号），这将会简单许多。
+假设标签属性中不会包含 `<` 和 `>`（包括被引号包裹的内容），这样就简单许多。

--- a/9-regular-expressions/10-regexp-greedy-and-lazy/4-find-html-tags-greedy-lazy/task.md
+++ b/9-regular-expressions/10-regexp-greedy-and-lazy/4-find-html-tags-greedy-lazy/task.md
@@ -12,4 +12,4 @@ let str = '<> <a href="/"> <input type="radio" checked> <b>';
 alert( str.match(reg) ); // '<a href="/">', '<input type="radio" checked>', '<b>'
 ```
 
-假设不包含 `<` 和 `>`（也包括引号），这将会简单许多。
+这里我们假设标签属性中不会包含 `<` 和 `>`（也包括引号），这将会简单许多。


### PR DESCRIPTION
**目标章节**：9-regular-expressions/10-regexp-greedy-and-lazy/4-find-html-tags-greedy-lazy

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
task.md | 无| 原文是Here we assume that tag attributes may not contain < and > (inside quotes too), that simplifies things a bit. 这里的翻译漏译了tag attributes