### PR TITLE
修正错误：“部分应用函数”不是“偏函数”

### DIFF
--- a/1-js/99-js-misc/03-currying-partials/article.md
+++ b/1-js/99-js-misc/03-currying-partials/article.md
@@ -42,7 +42,7 @@ alert( curriedSum(1)(2) ); // 3
 - 当它被像 `curriedSum(1)` 这样调用时，它的参数会被保存在词法环境中，然后返回一个新的包装器 `function(b)`。
 - 然后这个包装器被以 `2` 为参数调用，并且，它将该调用传递给原始的 `sum` 函数。
 
-柯里化更高级的实现，例如 lodash 库的 [_.curry](https://lodash.com/docs#curry)，会返回一个包装器，该包装器允许函数被正常调用或者以偏函数（partial）的方式调用：
+柯里化更高级的实现，例如 lodash 库的 [_.curry](https://lodash.com/docs#curry)，会返回一个包装器，该包装器允许函数被正常调用或者以部分应用函数（partial）的方式调用：
 
 ```js run
 function sum(a, b) {
@@ -52,7 +52,7 @@ function sum(a, b) {
 let curriedSum = _.curry(sum); // 使用来自 lodash 库的 _.curry
 
 alert( curriedSum(1, 2) ); // 3，仍可正常调用
-alert( curriedSum(1)(2) ); // 3，以偏函数的方式调用
+alert( curriedSum(1)(2) ); // 3，以部分应用函数的方式调用
 ```
 
 ## 柯里化？目的是什么？
@@ -88,14 +88,14 @@ log(new Date())("DEBUG")("some debug"); // log(a)(b)(c)
 现在，我们可以轻松地为当前日志创建便捷函数：
 
 ```js
-// logNow 会是带有固定第一个参数的日志的偏函数
+// logNow 会是带有固定第一个参数的日志的部分应用函数
 let logNow = log(new Date());
 
 // 使用它
 logNow("INFO", "message"); // [HH:mm] INFO message
 ```
 
-现在，`logNow` 是具有固定第一个参数的 `log`，换句话说，就是更简短的“偏应用函数（partially applied function）”或“偏函数（partial）”。
+现在，`logNow` 是具有固定第一个参数的 `log`，换句话说，就是更简短的“部分应用函数（partially applied function）”或“部分函数（partial）”。
 
 我们可以更进一步，为当前的调试日志（debug log）提供便捷函数：
 
@@ -107,7 +107,7 @@ debugNow("message"); // [HH:mm] DEBUG message
 
 所以：
 1. 柯里化之后，我们没有丢失任何东西：`log` 依然可以被正常调用。
-2. 我们可以轻松地生成偏函数，例如用于生成今天的日志的偏函数。
+2. 我们可以轻松地生成部分应用函数，例如用于生成今天的日志的部分应用函数。
 
 ## 高级柯里化实现
 
@@ -165,9 +165,9 @@ function curried(...args) {
 当我们运行它时，这里有两个 `if` 执行分支：
 
 1. 如果传入的 `args` 长度与原始函数所定义的（`func.length`）相同或者更长，那么只需要使用 `func.apply` 将调用传递给它即可。
-2. 否则，获取一个偏函数：我们目前还没调用 `func`。取而代之的是，返回另一个包装器 `pass`，它将重新应用 `curried`，将之前传入的参数与新的参数一起传入。
+2. 否则，获取一个部分应用函数：我们目前还没调用 `func`。取而代之的是，返回另一个包装器 `pass`，它将重新应用 `curried`，将之前传入的参数与新的参数一起传入。
 
-然后，如果我们再次调用它，我们将得到一个新的偏函数（如果没有足够的参数），或者最终的结果。
+然后，如果我们再次调用它，我们将得到一个新的部分应用函数（如果没有足够的参数），或者最终的结果。
 
 ```smart header="只允许确定参数长度的函数"
 柯里化要求函数具有固定数量的参数。
@@ -183,6 +183,6 @@ function curried(...args) {
 
 ## 总结
 
-**柯里化** 是一种转换，将 `f(a,b,c)` 转换为可以被以 `f(a)(b)(c)` 的形式进行调用。JavaScript 实现通常都保持该函数可以被正常调用，并且如果参数数量不足，则返回偏函数。
+**柯里化** 是一种转换，将 `f(a,b,c)` 转换为可以被以 `f(a)(b)(c)` 的形式进行调用。JavaScript 实现通常都保持该函数可以被正常调用，并且如果参数数量不足，则返回部分应用函数。
 
-柯里化让我们能够更容易地获取偏函数。就像我们在日志记录示例中看到的那样，普通函数 `log(date, importance, message)` 在被柯里化之后，当我们调用它的时候传入一个参数（如 `log(date)`）或两个参数（`log(date, importance)`）时，它会返回偏函数。
+柯里化让我们能够更容易地获取部分应用函数。就像我们在日志记录示例中看到的那样，普通函数 `log(date, importance, message)` 在被柯里化之后，当我们调用它的时候传入一个参数（如 `log(date)`）或两个参数（`log(date, importance)`）时，它会返回部分应用函数。


### PR DESCRIPTION
**目标章节**：例如 1-js/99-js-misc/03-currying-partials

**当前上游最新 commit**：-

**本 PR 所做更改如下：**
变更理由和 #1116 相同，复制如下：

修正一个概念：“partially applied function”应当翻译成“部分应用函数”，而非“偏函数”。

部分应用函数（partially applied function）：对于一个函数f，“固定”某些参数，得到函数g，g就是f的部分应用函数，例如文中mul和double的例子。
偏函数（partial function）：指一个函数不是对于所有输入都有输出（返回值），与“全函数（total function）”相对应。
全函数（total function）：指一个函数对于所有输入，都有输出（返回值），而不会抛异常，无限循环等。

Reference：
[Partial functions - HaskellWiki](https://wiki.haskell.org/Partial_functions)
[Partial application - HaskellWiki](https://wiki.haskell.org/Partial_application)

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | 无 | “部分应用函数”不是“偏函数”

> 注意，参考上游 commit 是指你所修改的文件，在英文仓库中同名文件的对应 commit，即你此次提交的修改的依据。如果本 PR 你只是提交一个文字或者语句优化，并非根据上游英文仓库的修改而提交的更新，则请填无。
