### PR TITLE
fixed typo

### DIFF
--- a/2-ui/99-ui-misc/02-selection-range/article.md
+++ b/2-ui/99-ui-misc/02-selection-range/article.md
@@ -452,7 +452,7 @@ As text: <span id="astext"></span>
 - `setPosition(node, offset)` —— `collapse` 的别名。
 - `collapseToStart()` —— 折叠（替换为空范围）到选择起点，
 - `collapseToEnd()` —— 折叠到选择终点，
-- `extend(node, offset)` —— 将选择的焦点（focus）移到给定的 `node`，位置偏移 `oofset`，
+- `extend(node, offset)` —— 将选择的焦点（focus）移到给定的 `node`，位置偏移 `offset`，
 - `setBaseAndExtent(anchorNode, anchorOffset, focusNode, focusOffset)` —— 用给定的起点 `anchorNode/anchorOffset` 和终点 `focusNode/focusOffset` 来替换选择范围。选中它们之间的所有内容。
 - `selectAllChildren(node)` —— 选择 `node` 的所有子节点。
 - `deleteFromDocument()` —— 从文档中删除所选择的内容。


### PR DESCRIPTION
**目标章节**：[zh.javascript.info](https://github.com/javascript-tutorial/zh.javascript.info/tree/master)/[2-ui](https://github.com/javascript-tutorial/zh.javascript.info/tree/master/2-ui)/[99-ui-misc](https://github.com/javascript-tutorial/zh.javascript.info/tree/master/2-ui/99-ui-misc)/[02-selection-range](https://github.com/javascript-tutorial/zh.javascript.info/tree/master/2-ui/99-ui-misc/02-selection-range)/article.md

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | 无 | 修改打字错误


