### PR TITLE
fix: outdated `Object.assign()` link

### DIFF
--- a/1-js/06-advanced-functions/02-rest-parameters-spread/article.md
+++ b/1-js/06-advanced-functions/02-rest-parameters-spread/article.md
@@ -227,7 +227,7 @@ alert( Array.from(str) ); // H,e,l,l,o
 
 ## 复制 array/object
 
-还记得我们 [之前讲过的](info:object-copy#ke-long-yu-he-bing-objectassign) `Object.assign()` 吗？
+还记得我们 [之前讲过的](info:object-copy#cloning-and-merging-object-assign) `Object.assign()` 吗？
 
 使用 spread 语法也可以做同样的事情（译注：也就是进行浅拷贝）。
 


### PR DESCRIPTION
**目标章节**：1-js/06-advanced-functions/02-rest-parameters-spread

**当前上游最新 commit**：https://github.com/javascript-tutorial/en.javascript.info/commit/733ff697c6c1101c130e2996f7eca860b2aa7ab9

**本 PR 所做更改如下：**

文件名 | 参考 commit | 更改（理由）
-|-|-
article.md | 826260a | 修改过时的 `Object.assign()` 链接
