### PR TITLE
fix(polyfills): core-js link

### DIFF
--- a/1-js/03-code-quality/06-polyfills/article.md
+++ b/1-js/03-code-quality/06-polyfills/article.md
@@ -85,7 +85,7 @@ JavaScript 是一种高度动态的语言。脚本可以添加/修改任何函�
 例如，以后熟悉了 JavaScript，你就可以搭建一个基于 [webpack](https://webpack.js.org/) 和 [babel-loader](https://github.com/babel/babel-loader) 插件的代码构建系统。
 
 展示对各种特征的当前支持情况的工具：
-- <https://https://compat-table.github.io/compat-table/es6/> —— 对于原生 JavaScript。
+- <https://compat-table.github.io/compat-table/es6/> —— 对于原生 JavaScript。
 - <https://caniuse.com/> —— 对于浏览器相关的函数。
 
 P.S. 谷歌的 Chrome 浏览器通常是对最新的语言特性的支持情况最好的浏览器，如果教程的示例运行失败，请尝试使用 Chrome 浏览器。不过，教程中的大多数示例都适用于任意的现代浏览器。


### PR DESCRIPTION
**目标章节**：例如 1-js/01-getting-started/1-intro

**当前上游最新 commit**：此处填写本项目英文版 https://github.com/javascript-tutorial/en.javascript.info 的最新 commit，例如 https://github.com/javascript-tutorial/zh.javascript.info/commit/b03ca00a992a73aaf213970e71f74ac1c04def33

**本 PR 所做更改如下：**

- core-js 链接修复

close #1205 
