### PR TITLE
docs: remove polyfill.io

### DIFF
--- a/1-js/03-code-quality/06-polyfills/article.md
+++ b/1-js/03-code-quality/06-polyfills/article.md
@@ -73,7 +73,6 @@ JavaScript 是一种高度动态的语言。脚本可以添加/修改任何函�
 
 两个有趣的 polyfill 库：
 - [core js](https://github.com/zloirock/core-js) 支持了很多特性，允许只包含需要的特性。
-- [polyfill.io](http://polyfill.io) 提供带有 polyfill 的脚本的服务，具体取决于特性和用户的浏览器。
 
 
 ## 总结


### PR DESCRIPTION
polyfill.io has been proven to be evil as it recently started implanting malicious scripts to jump to gambling sites.

https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet

**目标章节**：1-js/03-code-quality/06-polyfills

**当前上游最新 commit**：此处填写本项目英文版 https://github.com/javascript-tutorial/en.javascript.info 的最新 commit，例如 https://github.com/javascript-tutorial/zh.javascript.info/commit/b03ca00a992a73aaf213970e71f74ac1c04def33

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | [141fc29](https://github.com/javascript-tutorial/zh.javascript.info/commit/141fc29091dd33c3ff36bfb4029a8453b36c4d73) | remove evil polyfill.io

> 注意，参考上游 commit 是指你所修改的文件，在英文仓库中同名文件的对应 commit，即你此次提交的修改的依据。如果本 PR 你只是提交一个文字或者语句优化，并非根据上游英文仓库的修改而提交的更新，则请填无。
