### PR TITLE
更正翻译错误

### DIFF
--- a/6-data-storage/03-indexeddb/article.md
+++ b/6-data-storage/03-indexeddb/article.md
@@ -218,7 +218,7 @@ db.createObjectStore(name[, keyOptions]);
 db.createObjectStore('books', {keyPath: 'id'});
 ```
 
-**在 `upgradeneeded` 处理程序中，只有在创建数据库版本时，对象库被才能被 创建/修改。**
+**只有当数据库升级时，我们才能在`onupgradeneeded`事件的回调函数中创建或修改对象库。**
 
 这是技术上的限制。在 upgradeneedHandler 之外，可以添加/删除/更新数据，但是只能在版本更新期间创建/删除/更改对象库。
 


### PR DESCRIPTION
**目标章节**：6-data-storage/03-indexeddb/article.md

**当前上游最新 commit**： [https://github.com/javascript-tutorial/en.javascript.info/commit/b258d7d5b635c88228f7556e14fbe5e5ca7f736d]()

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
6-data-storage/03-indexeddb/article.md | 无| 翻译语义不明

原文：

> **An object store can only be created/modified while updating the DB version, in upgradeneeded handler.**

被翻译成

> **在 upgradeneeded 处理程序中，只有在创建数据库版本时，对象库被才能被 创建/修改。**

反正我一开始时看不懂时什么意思。


