### PR TITLE
修改“参数”为“实参”或“形参”，并优化部分翻译

### DIFF
--- a/1-js/02-first-steps/15-function-basics/article.md
+++ b/1-js/02-first-steps/15-function-basics/article.md
@@ -172,31 +172,31 @@ showMessage(from, "Hello"); // *Ann*: Hello
 alert( from ); // Ann
 ```
 
-当一个值被作为函数参数（parameter）传递时，它也被称为 **参数（argument）**。
+当一个值被传递给函数时，它被称为**实参（argument）**，而在函数定义中接收这些值的变量被称为**形参（parameter）**。
 
 换一种方式，我们把这些术语搞清楚：
 
-- 参数（parameter）是函数声明中括号内列出的变量（它是函数声明时的术语）。
-- 参数（argument）是调用函数时传递给函数的值（它是函数调用时的术语）。
+- 形参（parameter）：是函数声明中括号内列出的变量（它是函数声明时的术语）。
+- 实参（argument）：是调用函数时传递给函数的值（它是函数调用时的术语）。
 
-我们声明函数时列出它们的参数（parameters），然后调用它们传递参数（arguments）。
+我们声明函数时列出它们的形参（parameters），然后调用它们传递实参（arguments）。
 
-在上面的例子中，我们可以说：“函数 `showMessage` 被声明，并且带有两个参数（parameters），随后它被调用，两个参数（arguments）分别为 `from` 和 `"Hello"`”。
+在上面的例子中，我们可以说：“函数 `showMessage` 被声明，并且带有两个形参（parameters），随后它被调用，两个实参（arguments）分别为 `from` 和 `"Hello"`”。
 
 
 ## 默认值
 
-如果一个函数被调用，但有参数（argument）未被提供，那么相应的值就会变成 `undefined`。
+如果一个函数被调用，但有实参（argument）未被提供，那么相应的值就会变成 `undefined`。
 
-例如，之前提到的函数 `showMessage(from, text)` 可以只使用一个参数（argument）调用：
+例如，之前提到的函数 `showMessage(from, text)` 可以只使用一个实参（argument）调用：
 
 ```js
 showMessage("Ann");
 ```
 
-那不是错误，这样调用将输出 `"*Ann*: undefined"`。因为参数 `text` 的值未被传递，所以变成了 `undefined`。
+那不是错误，这样调用将输出 `"*Ann*: undefined"`。因为形参 `text` 的值未被传递，所以变成了 `undefined`。
 
-我们可以使用 `=` 为函数声明中的参数指定所谓的“默认”（如果对应参数的值未被传递则使用）值：
+我们可以使用 `=` 为函数声明中的形参指定所谓的“默认”（如果没有传递对应的实参则使用）值：
 
 ```js run
 function showMessage(from, *!*text = "no text given"*/!*) {
@@ -206,9 +206,9 @@ function showMessage(from, *!*text = "no text given"*/!*) {
 showMessage("Ann"); // Ann: no text given
 ```
 
-现在如果 `text` 参数未被传递，它将会得到值 `"no text given"`。
+现在如果 `text` 实参未被传递，它将会得到值 `"no text given"`。
 
-这里 `"no text given"` 是一个字符串，但它可以是更复杂的表达式，并且只会在缺少参数时才会被计算和分配。所以，这也是可能的：
+这里 `"no text given"` 是一个字符串，但它可以是更复杂的表达式，并且只会在缺少实参时才会被计算和分配。所以，这也是可能的：
 
 ```js run
 function showMessage(from, text = anotherFunction()) {
@@ -217,16 +217,16 @@ function showMessage(from, text = anotherFunction()) {
 }
 ```
 
-```smart header="默认参数的计算"
-在 JavaScript 中，每次函数在没带个别参数的情况下被调用，默认参数会被计算出来。
+```smart header="形参的默认值机制"
+在 JavaScript 中，如果调用函数时没有提供相应的实参，那么对应的形参会被赋予默认值。
 
-在上面的例子中，如果传递了参数 `text`，那么 `anotherFunction()` 就不会被调用。
+在上面的例子中，如果传递了 `text` 的实参，那么 `anotherFunction()` 就不会被调用。
 
-如果没传递参数 `text`，那么 `anotherFunction()` 就会被调用。
+如果没传递 `text` 的实参，那么 `anotherFunction()` 就会被调用。
 ```
 
-````smart header="在 JavaScript 老代码中的默认参数"
-几年前，JavaScript 不支持默认参数的语法。所以人们使用其他方式来设置默认参数。
+````smart header="在 JavaScript 老代码中的默认实参"
+几年前，JavaScript 不支持默认实参的语法。所以人们使用其他方式来设置默认实参。
 
 如今，我们会在旧代码中看到它们。
 
@@ -257,18 +257,18 @@ function showMessage(from, text) {
 ````
 
 
-### 后备的默认参数
+### 备选实参
 
-有些时候，将参数默认值的设置放在函数执行（相较更后期）而不是函数声明时，也行得通。
+有些时候，将形参的默认值的设置放在函数执行时（而不是在函数声明时），也行得通。
 
-我们可以通过将参数与 `undefined` 进行比较，来检查该参数是否在函数执行期间被传递进来：
+我们可以通过将形参与 `undefined` 进行比较，来检查对应的实参是否在函数执行期间被传递进来：
 
 ```js run
 function showMessage(text) {
   // ...
 
 *!*
-  if (text === undefined) { // 如果参数未被传递进来
+  if (text === undefined) { // 如果实参未被传递进来
     text = 'empty message';
   }
 */!*
@@ -516,13 +516,13 @@ function name(parameters, delimited, by, comma) {
 }
 ```
 
-- 作为参数传递给函数的值，会被复制到函数的局部变量。
+- 作为实参传递给函数的值，会被复制到函数的形参对应的局部变量中。
 - 函数可以访问外部变量。但它只能从内到外起作用。函数外部的代码看不到函数内的局部变量。
 - 函数可以返回值。如果没有返回值，则其返回的结果是 `undefined`。
 
-为了使代码简洁易懂，建议在函数中主要使用局部变量和参数，而不是外部变量。
+为了提高代码的简洁性和易读性，建议在函数内部主要使用局部变量和形参，而不是依赖外部变量。
 
-与不获取参数但将修改外部变量作为副作用的函数相比，获取参数、使用参数并返回结果的函数更容易理解。
+相比于那些不依赖于实参而是通过修改外部变量产生副作用的函数，那些依赖于实参、使用这些实参并返回结果的函数更容易理解。。
 
 函数命名：
 

--- a/1-js/02-first-steps/16-function-expressions/article.md
+++ b/1-js/02-first-steps/16-function-expressions/article.md
@@ -111,7 +111,7 @@ let sayHi = function() {
 
 让我们多举几个例子，看看如何将函数作为值来传递以及如何使用函数表达式。
 
-我们写一个包含三个参数的函数 `ask(question, yes, no)`：
+我们写一个包含三个形参的函数 `ask(question, yes, no)`：
 
 `question`
 : 关于问题的文本
@@ -140,13 +140,13 @@ function showCancel() {
   alert( "You canceled the execution." );
 }
 
-// 用法：函数 showOk 和 showCancel 被作为参数传入到 ask
+// 用法：函数 showOk 和 showCancel 被作为实参传入到 ask
 ask("Do you agree?", showOk, showCancel);
 ```
 
 在实际开发中，这样的函数是非常有用的。实际开发与上述示例最大的区别是，实际开发中的函数会通过更加复杂的方式与用户进行交互，而不是通过简单的 `confirm`。在浏览器中，这样的函数通常会绘制一个漂亮的提问窗口。但这是另外一件事了。
 
-`ask` 的两个参数值 `showOk` 和 `showCancel` 可以被称为 **回调函数** 或简称 **回调**。
+`ask` 的两个实参 `showOk` 和 `showCancel` 可以被称为 **回调函数** 或简称 **回调**。
 
 主要思想是我们传递一个函数，并期望在稍后必要时将其“回调”。在我们的例子中，`showOk` 是回答 "yes" 的回调，`showCancel` 是回答 "no" 的回调。
 


### PR DESCRIPTION
**目标章节**：

- 1-js/02-first-steps/15-function-basics/article.md
- 1-js/02-first-steps/16-function-expressions/article.md

**当前上游最新 commit**：

未参考上游

**本 PR 所做更改如下：**

修改文件（未参考上游）：

- 15-function-basics/article.md
- 16-function-expressions/article.md

在阅读此章节过程中发现文章翻译并未对形参（parameter）和实参（argument）进行区分

同时在访问仓库时发现有相关议题未被处理

在自己能力上对这两个章节做出了翻译修改，具体描述如下：

修改文中参数为形参或实参

- 15-function-basics中由于参数篇幅前文刚刚介绍参数，思考再三结合初学者视角决定不对介绍型参与实参之前的“参数”翻译进行修改

- 16-function-expressions中发现同样有少量“参数”未区分，因此也进行了修改

- 除上面两点之外对文中不易理解的翻译进行了修改如：后被默认参数->备选实参

本人仍为在校大学生，修改如有任何低级问题还请多多包容，如果愿意指出我将非常感激！