### PR TITLE
Fix：示例代码错误

### DIFF
--- a/1-js/06-advanced-functions/09-call-apply-decorators/article.md
+++ b/1-js/06-advanced-functions/09-call-apply-decorators/article.md
@@ -319,7 +319,7 @@ func.apply(context, args);
 这是它的最简形式：
 
 ```js
-let wrapper = function() {
+let wrapper = function(func) {
   return func.apply(this, arguments);
 };
 ```


### PR DESCRIPTION
**目标章节**：1-js/06-advanced-functions/09-call-apply-decorators
呼叫转移的最简形式示例代码，其中的函数缺少入参，会使其他人产生疑问
在本文的总结部分也有类似的问题，考虑到使用的是 `original ` ,它可以指代原始对象函数，看上去可以不做修改


**当前上游最新 commit**：此处填写本项目英文版 https://github.com/javascript-tutorial/en.javascript.info 的最新 commit，例如 https://github.com/javascript-tutorial/zh.javascript.info/commit/b03ca00a992a73aaf213970e71f74ac1c04def33

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | a23882d | 修改部分错误

> 注意，参考上游 commit 是指你所修改的文件，在英文仓库中同名文件的对应 commit，即你此次提交的修改的依据。如果本 PR 你只是提交一个文字或者语句优化，并非根据上游英文仓库的修改而提交的更新，则请填无。
