### PR TITLE
“slotted” 拼写错误

### DIFF
--- a/8-web-components/6-shadow-dom-style/article.md
+++ b/8-web-components/6-shadow-dom-style/article.md
@@ -238,7 +238,7 @@ customElements.define('user-card', class extends HTMLElement {
 }
 ```
 
-此外，`::sloated` 只能在 CSS 中使用，不能在 `querySelector` 中使用。
+此外，`::slotted` 只能在 CSS 中使用，不能在 `querySelector` 中使用。
 
 ## 用自定义 CSS 属性作为勾子
 


### PR DESCRIPTION
**目标章节**：8-web-components/6-shadow-dom-style

**当前上游最新 commit**：https://github.com/javascript-tutorial/zh.javascript.info/commit/5a17a97d7f6837f84d0aaa135335c9f2d861f569

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | 无 | ::slotted 拼写错误，写成了 “sloated”
