### PR TITLE
Update article with ESLint v9 deprecation notice

### DIFF
--- a/1-js/03-code-quality/02-coding-style/article.md
+++ b/1-js/03-code-quality/02-coding-style/article.md
@@ -339,6 +339,14 @@ function pow(x, n) {
 
 此外，某些 IDE 有内建的检查器，这非常方便，但是不像 ESLint 那样可自定义。
 
+```warn header="注意：此配置在现代 ESLint 中已过时"
+本文档中的示例使用的是旧版（Legacy）配置格式。在 **ESLint v9.0.0 及更高版本（如 v10+）** 中：
+1. **样式规则被废弃**：`indent` 等代码格式化规则自 `v8.53.0` 起已被官方废弃并冻结。
+2. **配置架构重构**：旧版的 `.eslintrc` 格式、`extends` 和 `env` 字段已被彻底移除，新版强制使用扁平配置（Flat Config）架构（即 `eslint.config.js`）。
+
+详情及迁移方案请参阅官方公告：[Deprecating Formatting Rules](https://eslint.org/blog/2023/10/deprecating-formatting-rules/) 以及 [Flat Config 迁移指南](https://eslint.org/docs/latest/use/configure/migration-guide)。
+```
+
 ## 总结
 
 本章描述的（和提到的代码风格指南中的）所有语法规则，都旨在帮助你提高代码可读性。它们都是值得商榷的。


### PR DESCRIPTION
Added warning about deprecated ESLint configuration and formatting rules.

**目标章节**：例如 1-js/01-getting-started/1-intro

**当前上游最新 commit**：此处填写本项目英文版 https://github.com/javascript-tutorial/en.javascript.info 的最新 commit，例如 https://github.com/javascript-tutorial/zh.javascript.info/commit/b03ca00a992a73aaf213970e71f74ac1c04def33

**本 PR 所做更改如下：**

文件名 | 参考上游 commit | 更改（理由）
-|-|-
article.md | a23882d | 修改部分错误

> 注意，参考上游 commit 是指你所修改的文件，在英文仓库中同名文件的对应 commit，即你此次提交的修改的依据。如果本 PR 你只是提交一个文字或者语句优化，并非根据上游英文仓库的修改而提交的更新，则请填无。
